### PR TITLE
Add optional version check for plugin dependencies

### DIFF
--- a/private/language/afrikaans.php
+++ b/private/language/afrikaans.php
@@ -1310,7 +1310,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/afrikaans_utf-8.php
+++ b/private/language/afrikaans_utf-8.php
@@ -1309,7 +1309,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/bosnian.php
+++ b/private/language/bosnian.php
@@ -1313,7 +1313,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/bosnian_utf-8.php
+++ b/private/language/bosnian_utf-8.php
@@ -1313,7 +1313,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/bulgarian.php
+++ b/private/language/bulgarian.php
@@ -1310,7 +1310,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/bulgarian_utf-8.php
+++ b/private/language/bulgarian_utf-8.php
@@ -1309,7 +1309,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/catalan.php
+++ b/private/language/catalan.php
@@ -1308,7 +1308,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/catalan_utf-8.php
+++ b/private/language/catalan_utf-8.php
@@ -1307,7 +1307,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/chinese_simplified_utf-8.php
+++ b/private/language/chinese_simplified_utf-8.php
@@ -1313,7 +1313,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/chinese_traditional_utf-8.php
+++ b/private/language/chinese_traditional_utf-8.php
@@ -1312,7 +1312,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/croatian.php
+++ b/private/language/croatian.php
@@ -1309,7 +1309,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/croatian_utf-8.php
+++ b/private/language/croatian_utf-8.php
@@ -1311,7 +1311,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/czech.php
+++ b/private/language/czech.php
@@ -1308,7 +1308,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/czech_utf-8.php
+++ b/private/language/czech_utf-8.php
@@ -1309,7 +1309,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/danish.php
+++ b/private/language/danish.php
@@ -1308,7 +1308,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/danish_utf-8.php
+++ b/private/language/danish_utf-8.php
@@ -1308,7 +1308,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/dutch.php
+++ b/private/language/dutch.php
@@ -1315,7 +1315,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/dutch_utf-8.php
+++ b/private/language/dutch_utf-8.php
@@ -1316,7 +1316,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/english.php
+++ b/private/language/english.php
@@ -1317,6 +1317,7 @@ $LANG32 = array(
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
     89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/english_utf-8.php
+++ b/private/language/english_utf-8.php
@@ -1321,6 +1321,7 @@ $LANG32 = array(
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
     89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/estonian.php
+++ b/private/language/estonian.php
@@ -1310,7 +1310,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/estonian_utf-8.php
+++ b/private/language/estonian_utf-8.php
@@ -1310,7 +1310,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/farsi_utf-8.php
+++ b/private/language/farsi_utf-8.php
@@ -1297,7 +1297,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/finnish.php
+++ b/private/language/finnish.php
@@ -1312,7 +1312,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/finnish_utf-8.php
+++ b/private/language/finnish_utf-8.php
@@ -1312,7 +1312,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/french_canada.php
+++ b/private/language/french_canada.php
@@ -1312,7 +1312,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/french_canada_utf-8.php
+++ b/private/language/french_canada_utf-8.php
@@ -1317,6 +1317,7 @@ $LANG32 = array(
     87 => 'Balise automatique d`installation',
     88 => 'Etes-vous sûr de vouloir supprimer ce plugin?',
     89 => 'Êtes-vous absolument sûr de vouloir supprimer ce plugin? Cela se traduira par la suppression de tous les fichiers et répertoires liés à ce plugin, et de ré-installer ce plugin, vous devrez télécharger une autre copie.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/french_france.php
+++ b/private/language/french_france.php
@@ -1308,7 +1308,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/french_france_utf-8.php
+++ b/private/language/french_france_utf-8.php
@@ -1308,7 +1308,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/german.php
+++ b/private/language/german.php
@@ -1313,7 +1313,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/german_formal.php
+++ b/private/language/german_formal.php
@@ -1313,7 +1313,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/german_formal_utf-8.php
+++ b/private/language/german_formal_utf-8.php
@@ -1313,7 +1313,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/german_utf-8.php
+++ b/private/language/german_utf-8.php
@@ -1313,7 +1313,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/hebrew_utf-8.php
+++ b/private/language/hebrew_utf-8.php
@@ -1311,7 +1311,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/hellenic.php
+++ b/private/language/hellenic.php
@@ -1317,7 +1317,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/hellenic_utf-8.php
+++ b/private/language/hellenic_utf-8.php
@@ -1317,7 +1317,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/indonesian.php
+++ b/private/language/indonesian.php
@@ -1309,7 +1309,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/indonesian_utf-8.php
+++ b/private/language/indonesian_utf-8.php
@@ -1309,7 +1309,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/italian.php
+++ b/private/language/italian.php
@@ -1310,7 +1310,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/italian_utf-8.php
+++ b/private/language/italian_utf-8.php
@@ -1310,7 +1310,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/japanese_utf-8.php
+++ b/private/language/japanese_utf-8.php
@@ -1316,7 +1316,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/korean.php
+++ b/private/language/korean.php
@@ -1310,7 +1310,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/korean_utf-8.php
+++ b/private/language/korean_utf-8.php
@@ -1310,7 +1310,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/norwegian.php
+++ b/private/language/norwegian.php
@@ -1322,7 +1322,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/norwegian_utf-8.php
+++ b/private/language/norwegian_utf-8.php
@@ -1322,7 +1322,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/polish.php
+++ b/private/language/polish.php
@@ -1309,7 +1309,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/polish_utf-8.php
+++ b/private/language/polish_utf-8.php
@@ -1309,7 +1309,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/portuguese.php
+++ b/private/language/portuguese.php
@@ -1308,7 +1308,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/portuguese_brazil.php
+++ b/private/language/portuguese_brazil.php
@@ -1313,7 +1313,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/portuguese_brazil_utf-8.php
+++ b/private/language/portuguese_brazil_utf-8.php
@@ -1313,7 +1313,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/portuguese_utf-8.php
+++ b/private/language/portuguese_utf-8.php
@@ -1308,7 +1308,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/romanian.php
+++ b/private/language/romanian.php
@@ -1308,7 +1308,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/romanian_utf-8.php
+++ b/private/language/romanian_utf-8.php
@@ -1308,7 +1308,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/russian.php
+++ b/private/language/russian.php
@@ -1325,7 +1325,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/russian_utf-8.php
+++ b/private/language/russian_utf-8.php
@@ -1325,7 +1325,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/slovak.php
+++ b/private/language/slovak.php
@@ -1309,7 +1309,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/slovak_utf-8.php
+++ b/private/language/slovak_utf-8.php
@@ -1309,7 +1309,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/slovenian.php
+++ b/private/language/slovenian.php
@@ -1312,7 +1312,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/slovenian_utf-8.php
+++ b/private/language/slovenian_utf-8.php
@@ -1312,7 +1312,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/spanish.php
+++ b/private/language/spanish.php
@@ -1307,7 +1307,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/spanish_argentina.php
+++ b/private/language/spanish_argentina.php
@@ -1307,7 +1307,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/spanish_argentina_utf-8.php
+++ b/private/language/spanish_argentina_utf-8.php
@@ -1307,7 +1307,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/spanish_utf-8.php
+++ b/private/language/spanish_utf-8.php
@@ -1310,7 +1310,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/swedish.php
+++ b/private/language/swedish.php
@@ -1313,7 +1313,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/swedish_utf-8.php
+++ b/private/language/swedish_utf-8.php
@@ -1313,7 +1313,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/turkish.php
+++ b/private/language/turkish.php
@@ -1309,7 +1309,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/turkish_utf-8.php
+++ b/private/language/turkish_utf-8.php
@@ -1309,7 +1309,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/ukrainian.php
+++ b/private/language/ukrainian.php
@@ -1313,7 +1313,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/ukrainian_koi8-u.php
+++ b/private/language/ukrainian_koi8-u.php
@@ -1313,7 +1313,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################

--- a/private/language/ukrainian_utf-8.php
+++ b/private/language/ukrainian_utf-8.php
@@ -1313,7 +1313,8 @@ $LANG32 = array(
     86 => 'Automated Autotag Installer Error',
     87 => 'Autotag Installer',
     88 => 'Are you sure you want to remove this plugin?',
-    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.'
+    89 => 'Are you absolutely sure you want to remove this plugin?  This will result in the deletion of all of the files and directories relating to this plugin, and to re-install this plugin, you will have to upload another copy.',
+    90 => 'Version <b>%s</b> of the <b>%s</b> plugin is required, but version <b>%s</b> is installed. Please update the %s plugin.',
 );
 
 ###############################################################################


### PR DESCRIPTION
In plugin.xml, allow either "<requires>plugin</requires>" as usual, or "<requires>plugin,version</requires>" to require a minimum version. Updated language files to reflect the new check.