### PR TITLE
Set permissions to 0755 for user's directory

### DIFF
--- a/public_html/ckeditor/plugins/filemanager/connectors/php/user.config.php
+++ b/public_html/ckeditor/plugins/filemanager/connectors/php/user.config.php
@@ -67,7 +67,7 @@ if ( $inRoot ) {
     if ( $_CK_CONF['filemanager_per_user_dir'] ) {
         $filePath = $fileroot . $_CK_CONF['filemanager_fileroot'] . $uid . '/';
         if ( !is_dir($_CONF['path_html'].$filePath) ) {
-            $rc = @mkdir($_CONF['path_html'].$filePath, 0777, true);
+            $rc = @mkdir($_CONF['path_html'].$filePath, 0755, true);
             if ( $rc === false ) {
                 $filePath = $fileroot . $_CK_CONF['filemanager_fileroot'];
             }


### PR DESCRIPTION
Default permissions are 0777 as the script is delivered. The IMPORTANT note at the top recommends changing this to suit the needs of the site. Should be changed to 0755.