### PR TITLE
Calendar is now horizontally scrollable when in small viewport

### DIFF
--- a/public_html/layout/cms/plugins/calendar/calendar.thtml
+++ b/public_html/layout/cms/plugins/calendar/calendar.thtml
@@ -62,6 +62,7 @@
 </div>
 
 <div class="uk-clearfix"></div>
+<div class="uk-overflow-container">
 <table id="cal-body">
     <tr>
         <td>&nbsp;</td>
@@ -75,6 +76,7 @@
     </tr>
     {cal_week}
 </table>
+</div>
 <table class="uk-table uk-text-center">
     <tr>
         <td>


### PR DESCRIPTION
This change fixes issue 62. Calendar is now horizontally scrollable when in small viewport such as an iphone in vertical view.
https://github.com/glFusion/glfusion/issues/62