### PR TITLE
Fixes responsiveness for poll_vote autotag

### DIFF
--- a/private/plugins/polls/templates/pollblock.thtml
+++ b/private/plugins/polls/templates/pollblock.thtml
@@ -1,7 +1,6 @@
 {# begin {templatelocation} #}
 <span class="uk-align-right">{edit_icon}</span>
-<h3>{poll_topic}</h3>
-<form class="uk-form uk-form-horizontal" action="{poll_vote_url}" id="Vote{poll_id}" method="post">
+<h3>{poll_topic}</h3><form class="uk-form uk-form-horizontal uk-width-1-1" action="{poll_vote_url}" id="Vote{poll_id}" method="post">
   <input type="hidden" name="pid" value="{poll_id}">
   {poll_questions}
   <span class="uk-text-small">{poll_notification}</span><br>

--- a/private/plugins/polls/templates/pollblock.thtml
+++ b/private/plugins/polls/templates/pollblock.thtml
@@ -1,6 +1,6 @@
 {# begin {templatelocation} #}
 <span class="uk-align-right">{edit_icon}</span>
-<h3>{poll_topic}</h3>
+{!if poll_topic}<h3>{poll_topic}</h3>{!elseif edit_icon}<br />{!endif}
 <form class="uk-form uk-form-horizontal uk-width-1-1" action="{poll_vote_url}" id="Vote{poll_id}" method="post">
   <input type="hidden" name="pid" value="{poll_id}">
   {poll_questions}

--- a/private/plugins/polls/templates/pollblock.thtml
+++ b/private/plugins/polls/templates/pollblock.thtml
@@ -1,6 +1,7 @@
 {# begin {templatelocation} #}
 <span class="uk-align-right">{edit_icon}</span>
-<h3>{poll_topic}</h3><form class="uk-form uk-form-horizontal uk-width-1-1" action="{poll_vote_url}" id="Vote{poll_id}" method="post">
+<h3>{poll_topic}</h3>
+<form class="uk-form uk-form-horizontal uk-width-1-1" action="{poll_vote_url}" id="Vote{poll_id}" method="post">
   <input type="hidden" name="pid" value="{poll_id}">
   {poll_questions}
   <span class="uk-text-small">{poll_notification}</span><br>


### PR DESCRIPTION
Note: when using poll_vote autotag users will have to wrap the tag in a container if they want more control over the width of polls within an article ect. I felt this was better than forcing a max width. Now the user can freely choose the width without having to go into the templates.