### PR TITLE
Adds Character Counter To Fields

### DIFF
--- a/public_html/layout/cms/admin/story/storyeditor.thtml
+++ b/public_html/layout/cms/admin/story/storyeditor.thtml
@@ -77,10 +77,10 @@ function actionClick( $action ) {
 		<div id="story_id" class="uk-panel uk-panel-box uk-margin">
 			<div class="uk-grid ">
 				<div class="uk-width-medium-2-3">
-					<strong>{lang_title}</strong>&nbsp;<input class="uk-width-1-1" id="title" type="text" name="title" value="{story_title}">
+					<strong>{lang_title}</strong>&nbsp;<span id="title-count" class="uk-badge uk-badge-notification uk-margin-small-bottom"></span>&nbsp;<input class="uk-width-1-1" id="title" type="text" name="title" value="{story_title}">
 				</div>
 				<div class="uk-width-medium-1-3">
-					<strong>{lang_sid}</strong>&nbsp;<input class="uk-width-1-1" id="sid" class="required alphanumeric" maxlength="128" type="text" name="sid" value="{story_id}">
+					<strong>{lang_sid}</strong>&nbsp;<span id="sid-count" class="uk-badge uk-badge-notification uk-margin-small-bottom"></span>&nbsp;<input class="uk-width-1-1" id="sid" class="required alphanumeric" maxlength="128" type="text" name="sid" value="{story_id}">
 				</div>
 			</div>
 		</div>
@@ -127,7 +127,7 @@ function actionClick( $action ) {
 						<legend>{lang_publishoptions}</legend>
 
 						<div class="uk-form-row">
-							<label class="uk-form-label" for="topic">{$LANG24[98]}</label>
+							<label class="uk-form-label" for="topic">{$LANG24[98]}&nbsp;<span id="subtitle-count" class="uk-badge uk-badge-notification uk-margin-small-bottom"></span></label>
 							<div class="uk-form-controls">
 								<input class="uk-width-1-1" id="subtitle" type="text" name="subtitle" value="{story_subtitle}">
 							</div>
@@ -292,21 +292,21 @@ function actionClick( $action ) {
 						<legend>{lang_attribution}</legend>
 
 						<div class="uk-form-row">
-							<label class="uk-form-label" for="attribution_url">{lang_attribution_url}</label>
+							<label class="uk-form-label" for="attribution_url">{lang_attribution_url}&nbsp;<span id="attribution_url-count" class="uk-badge uk-badge-notification uk-margin-small-bottom"></span></label>
 							<div class="uk-form-controls">
 								<input class="uk-form-width-large" type="text" id="attribution_url" name="attribution_url" value="{attribution_url}">
 							</div>
 						</div>
 
 						<div class="uk-form-row">
-							<label class="uk-form-label" for="attribution_name">{lang_attribution_name}</label>
+							<label class="uk-form-label" for="attribution_name">{lang_attribution_name}&nbsp;<span id="attribution_name-count" class="uk-badge uk-badge-notification uk-margin-small-bottom"></span></label>
 							<div class="uk-form-controls">
 								<input class="uk-form-width-medium" type="text" id="attribution_name" name="attribution_name" value="{attribution_name}">
 							</div>
 						</div>
 
 						<div class="uk-form-row">
-							<label class="uk-form-label" for="attribution_author">{lang_attribution_author}</label>
+							<label class="uk-form-label" for="attribution_author">{lang_attribution_author}&nbsp;<span id="attribution_author-count" class="uk-badge uk-badge-notification uk-margin-small-bottom"></span></label>
 							<div class="uk-form-controls">
 								<input class="uk-form-width-medium" type="text" id="attribution_author" name="attribution_author" value="{attribution_author}">
 							</div>
@@ -524,6 +524,46 @@ function actionClick( $action ) {
 </script>
 <script>
 	$("#frmstory").validate();
+</script>
+<script>
+		$(function(){
+			// Story Title
+            $("#title").characterCounter({
+            limit: '128',
+            counterSelector: '#title-count' 
+            });
+            
+            // Story ID
+            $("#sid").characterCounter({
+            limit: '128',
+            counterSelector: '#sid-count' 
+            });
+            
+            // Story Subtitle
+            $("#subtitle").characterCounter({
+            limit: '128',
+            counterSelector: '#subtitle-count' 
+            });
+            
+            // Attribution URL
+            $("#attribution_url").characterCounter({
+            limit: '255',
+            counterSelector: '#attribution_url-count' 
+            });
+            
+            // Attribution Name
+            $("#attribution_name").characterCounter({
+            limit: '255',
+            counterSelector: '#attribution_name-count' 
+            });
+            
+            // Attribution Author
+            $("#attribution_author").characterCounter({
+            limit: '255',
+            counterSelector: '#attribution_author-count' 
+            });
+            
+            });
 </script>
 <script src="{site_url}/javascript/activitytimer.js" type="text/javascript"></script>
 {# end {templatelocation} #}


### PR DESCRIPTION
Mark I'm not sure how to add the proper javascript to switch in uk-badge-danger when character limit is exceeded but the javascript library does allow for an exceeded trigger. 

https://github.com/dtisgodsson/jquery-character-counter

Here on the options

{
limit: 150,
counterWrapper: 'span',
counterCssClass: 'counter',
counterFormat: '%1',
counterExceededCssClass: 'exceeded',
onExceed: function(count){},
onDeceed: function(count){},
customFields: {}
}

limit - the number of characters you wish to limit.
counterWrapper - the element you wish to wrap your counter in.
counterCssClass - the CSS class to apply to your counter.
counterFormat - the format of your counter text where '%1' will be replaced with the remaining character count.
counterExceededCssClass - the CSS class to apply when your limit has been exceeded.
onExceed - this function is called when the limit is breached
onDeceed - this function is called when the limit, having previously been exceeded, is now deceeded customFields - key value pairs of custom options to be added to the counter such as class, data attributes etc.