### PR TITLE
Handle utf-8 space in autotags

### DIFF
--- a/private/system/lib-plugins.php
+++ b/private/system/lib-plugins.php
@@ -1949,6 +1949,7 @@ function PLG_replaceTags($content,$namespace='',$operation='', $plugin = '')
                         (($next_tag === false) OR ($end_pos < $next_tag))) {
                     $taglength = $end_pos - $start_pos + 1;
                     $tag = utf8_substr ($content, $start_pos, $taglength);
+                    $tag = str_replace("\xc2\xa0", ' ', $tag);
                     $parms = explode (' ', $tag);
 
                     // Extra test to see if autotag was entered with a space

--- a/private/system/lib-plugins.php
+++ b/private/system/lib-plugins.php
@@ -1949,8 +1949,7 @@ function PLG_replaceTags($content,$namespace='',$operation='', $plugin = '')
                         (($next_tag === false) OR ($end_pos < $next_tag))) {
                     $taglength = $end_pos - $start_pos + 1;
                     $tag = utf8_substr ($content, $start_pos, $taglength);
-                    $tag = str_replace("\xc2\xa0", ' ', $tag);
-                    $parms = explode (' ', $tag);
+                    $parms = explode (' ', str_replace("\xc2\xa0", ' ', $tag));
 
                     // Extra test to see if autotag was entered with a space
                     // after the module name


### PR DESCRIPTION
This will hopefully get rid of the UTF-8 `&nbsp;` character and allow autotags to be exploded correctly.