### PR TITLE
Remove dependency on forum plugin

### DIFF
--- a/private/system/lib-comment.php
+++ b/private/system/lib-comment.php
@@ -2186,8 +2186,6 @@ function plugin_getiteminfo_comment($id, $what, $uid = 0, $options = array())
         return $retval;
     }
 
-    USES_forum_format();
-
     if ($id == '*') {
         if ( $buildingSearchIndex ) {
             $where = " WHERE queued = 0 AND pid=0 ";


### PR DESCRIPTION
The call to USES_forum_format() in lib-comment.php causes an error if the forum plugin is not installed or is disabled. Comment submission and moderation appears to work normally without this call.