### PR TITLE
Make img the default template

### DIFF
--- a/private/plugins/forum/classes/badge.class.php
+++ b/private/plugins/forum/classes/badge.class.php
@@ -252,6 +252,7 @@ class Badge
             $this->url = '';
             break;
         case 'img':
+        default:
             $tpl_filename = 'badge_img.thtml';
             $this->url = self::getImageUrl($this->fb_data);
             break;


### PR DESCRIPTION
Added getRank() to topic.inc.php and modified topic_full.thtml. I have getRank() setting the user level text in the template, but it still returns an array of (stars, text) if you'd rather have the caller set the text instead.