### PR TITLE
Additional cache clearing options

### DIFF
--- a/private/system/classes/Cache.php
+++ b/private/system/classes/Cache.php
@@ -284,6 +284,28 @@ final class Cache
     }
 
     /**
+     * delete cache items tagged by at least one of several tags
+     * @param array $tags
+     * @return none
+     */
+    public function deleteItemsByTags($tags)
+    {
+        if (!is_array($tags)) $tags = array($tags);
+        $this->internalCacheInstance->deleteItemsByTags($tags);
+    }
+
+    /**
+     * delete cache items tagged with all tags
+     * @param array $tags
+     * @return none
+     */
+    public function deleteItemsByTagsAll($tags)
+    {
+        if (!is_array($tags)) $tags = array($tags);
+        $this->internalCacheInstance->deleteItemsByTagsAll($tags);
+    }
+
+    /**
      * @param string $tag
      * @return mixed items
      */

--- a/public_html/admin/group.php
+++ b/public_html/admin/group.php
@@ -662,6 +662,7 @@ function GROUP_save($grp_id, $grp_name, $grp_descr, $grp_admin, $grp_gl_core, $g
         } else {
             PLG_groupChanged ($grp_id, 'edit');
         }
+        \glFusion\Cache::getInstance()->deleteItemsByTags(array('groups', 'group_' . $grp_id));
         COM_setMessage(49);
         $url = $_CONF['site_admin_url'] . '/group.php';
         $url .= (isset($_POST['chk_showall']) && ($_POST['chk_showall'] == 1)) ? '?chk_showall=1' : '';
@@ -1178,6 +1179,7 @@ function GROUP_delete($grp_id)
     DB_delete ($_TABLES['groups'], 'grp_id', $grp_id);
 
     PLG_groupChanged ($grp_id, 'delete');
+    \glFusion\Cache::getInstance()->deleteItemsByTags(array('groups', 'group_' . $grp_id));
 
     COM_setMessage(50);
     $url = $_CONF['site_admin_url'] . '/group.php';

--- a/public_html/admin/group.php
+++ b/public_html/admin/group.php
@@ -662,7 +662,7 @@ function GROUP_save($grp_id, $grp_name, $grp_descr, $grp_admin, $grp_gl_core, $g
         } else {
             PLG_groupChanged ($grp_id, 'edit');
         }
-        \glFusion\Cache::getInstance()->deleteItemsByTags(array('groups', 'group_' . $grp_id));
+        glFusion\Cache::getInstance()->deleteItemsByTags(array('menu', 'groups', 'group_' . $grp_id));
         COM_setMessage(49);
         $url = $_CONF['site_admin_url'] . '/group.php';
         $url .= (isset($_POST['chk_showall']) && ($_POST['chk_showall'] == 1)) ? '?chk_showall=1' : '';
@@ -1179,7 +1179,7 @@ function GROUP_delete($grp_id)
     DB_delete ($_TABLES['groups'], 'grp_id', $grp_id);
 
     PLG_groupChanged ($grp_id, 'delete');
-    \glFusion\Cache::getInstance()->deleteItemsByTags(array('groups', 'group_' . $grp_id));
+    glFusion\Cache::getInstance()->deleteItemsByTags(array('menu', 'groups', 'group_' . $grp_id));
 
     COM_setMessage(50);
     $url = $_CONF['site_admin_url'] . '/group.php';

--- a/public_html/admin/user.php
+++ b/public_html/admin/user.php
@@ -1943,6 +1943,7 @@ function USER_save($uid)
         echo $retval;
         exit;
     }
+    glFusion\Cache::getInstance()->deleteItemsByTags(array('menu', 'users', 'user_' . $uid));
 
     if ($_USER_VERBOSE) COM_errorLog("***************leaving USER_save()*****************",1);
 
@@ -2452,7 +2453,7 @@ function USER_delete($uid)
     if (!USER_deleteAccount ($uid)) {
         return COM_refresh ($_CONF['site_admin_url'] . '/user.php');
     }
-    $c = glFusion\Cache::getInstance()->deleteItemsByTag('menu');
+    glFusion\Cache::getInstance()->deleteItemsByTags(array('menu', 'users', 'user_' . $uid));
     COM_setMessage(22);
     return COM_refresh ($_CONF['site_admin_url'] . '/user.php');
 }


### PR DESCRIPTION
Add deleteItemsByTags and deleteItemsByTagsAll functions to Cache class.
Delete additional tags when users or groups are saved or deleted.