### PR TITLE
Fixes errant opening tag

### DIFF
--- a/private/system/autotags/headlines.thtml
+++ b/private/system/autotags/headlines.thtml
@@ -58,7 +58,7 @@
 {!endif}
 				</header>
 				<div class="uk-clearfix"></div>
-				<span itemprop="description">{text}</span>
+				<div itemprop="description">{text}</p></div>
 {!if readmore_url}
 				<br><a class="uk-text" href="{readmore_url}">{lang_readmore} <i class="uk-icon-angle-double-right"></i></a>
 {!endif}


### PR DESCRIPTION
There is an errant opening <p> tag hard coded somewhere and can't find it. This is a temporary fix until found

span changed to div to fix "Element p not allowed as child of element span in this context." when tested with w3 validator