### PR TITLE
Fix `$db not defined` error in _addConfigItem()

### DIFF
--- a/private/system/lib-install.php
+++ b/private/system/lib-install.php
@@ -1106,6 +1106,7 @@ if ( !function_exists('_addConfigItem')) {
                        serialize($data['default_value']));
 
         try {
+            $db = Database::getInstance();
             $db->conn->insert(
                 $_TABLES['conf_values'],
                 array(


### PR DESCRIPTION
The DB variable is used before being defined in lib-install.php _addConfigItem() function.