### PR TITLE
Don't print the staticpage title unless wrapped in a block

### DIFF
--- a/private/plugins/staticpages/functions.inc
+++ b/private/plugins/staticpages/functions.inc
@@ -467,7 +467,9 @@ function SP_printPage ($page, $A)
     $print->set_var ('page_title', $_CONF['site_name'] . ' - ' . $A['sp_title']);
     $sp_url = COM_buildUrl ($_CONF['site_url'].'/page.php?page=' . $page);
     $print->set_var ('sp_url', $sp_url);
-    $print->set_var ('sp_title', $A['sp_title']);
+    if (isset($A['sp_inblock']) && $A['sp_inblock']) {
+        $print->set_var ('sp_title', $A['sp_title']);
+    }
     $print->set_var ('sp_content', SP_render_content ($A['sp_content'], $A['sp_php']));
     $print->set_var ('sp_hits', COM_numberFormat ($A['sp_hits']));
     $printable = COM_buildURL($_CONF['site_url'].'/page.php?page=' . $page . '&amp;mode=print');

--- a/private/system/lib-user.php
+++ b/private/system/lib-user.php
@@ -870,7 +870,9 @@ function USER_addGroup ($groupid, $uid = '')
                             Database::INTEGER
                         )
         );
-
+        Cache::getInstance()->deleteItemsByTagsAll(
+            array('groups', 'user_' . $uid)
+        );
         return true;
     }
 }
@@ -910,6 +912,9 @@ function  USER_delGroup ($groupid, $uid = '')
 
     if (($groupid > 0) && SEC_inGroup ($groupid, $uid)) {
         $db->conn->delete($_TABLES['group_assignments'],array('ug_main_grp_id'=>$groupid,'ug_uid'=>$uid),array(Database::INTEGER,Database::INTEGER));
+        Cache::getInstance()->deleteItemsByTagsAll(
+            array('groups', 'user_' . $uid)
+        );
         return true;
     } else {
         return false;


### PR DESCRIPTION
If sp_inblock is set, the page is displayed with its title. If not set, any title is assumed to be in the content. This fix is to make SP_printPage() behave the same way, other the title appears to be duplicated.