### PR TITLE
Use ADMIN_list to create filemgmt download history report

### DIFF
--- a/private/plugins/filemgmt/templates/downloadhistory.thtml
+++ b/private/plugins/filemgmt/templates/downloadhistory.thtml
@@ -1,0 +1,21 @@
+{# begin {templatelocation} #}
+<h2 style="text-align:center;">{$LANG_FILEMGMT['DownloadReport']}</h2>
+<h4>File: {dtitle}</h4>
+{admin_list}
+{!if 0}
+<table class="uk-table uk-table-hover uk-table-striped plugin">
+    <tr>
+        <th width="20%">Date</td>
+        <th width="20%">User</td>
+        <th width="20%">Remote IP</td>
+    </tr>
+<!-- BEGIN dataRow -->
+    <tr>
+        <td>{date}</td>
+        <td>{username}</td>
+        <td>{remote_ip}</td>
+    </tr>
+<!-- END dataRow -->
+</table>
+{!endif}
+{# end {templatelocation} #}

--- a/public_html/filemgmt/downloadhistory.php
+++ b/public_html/filemgmt/downloadhistory.php
@@ -40,6 +40,8 @@ require_once '../lib-common.php';
 include_once $_CONF['path'].'plugins/filemgmt/include/header.php';
 include_once $_CONF['path'].'plugins/filemgmt/include/functions.php';
 
+$lid = COM_applyFilter($_GET['lid'],true);
+
 // Comment out the following security check if you want general filemgmt users access to this report
 if (!SEC_hasRights("filemgmt.edit")) {
     COM_errorLOG("Downloadhistory.php => Filemgmt Plugin Access denied. Attempted access for file ID:{$lid}, Remote address is:{$_SERVER['REMOTE_ADDR']}");
@@ -50,8 +52,6 @@ if (!SEC_hasRights("filemgmt.edit")) {
 USES_lib_admin();
 
 $display = COM_siteHeader('none');
-
-$lid = COM_applyFilter($_GET['lid'],true);
 
 $result=DB_query("SELECT title FROM {$_TABLES['filemgmt_filedetail']} WHERE lid='".DB_escapeString($lid)."'");
 list($dtitle)=DB_fetchArray($result);


### PR DESCRIPTION
Create a cleaner file download history report by removing hardcoded styles and HTML. I left comments in the template and code to use a templated table instead of ADMIN_list() if that's preferred, but I think ADMIN_list is the most consistent way to go.