### PR TITLE
Pass content to PLG_itemPreSave() by address

### DIFF
--- a/private/system/lib-plugins.php
+++ b/private/system/lib-plugins.php
@@ -720,7 +720,7 @@ function PLG_commentPreSave($uid, &$title, &$comment, $sid, $pid, $type, &$postm
 * @return string empty is no error, error message if error was encountered
 *
 */
-function PLG_itemPreSave($type, $content)
+function PLG_itemPreSave($type, &$content)
 {
     global $_PLUGINS;
 


### PR DESCRIPTION
Allow plugins to modify content that is sent to PLG_itemPreSave(). The only return from plugin_itempresave_* functions is an error message, this would allow for additional text filtering. May help solve https://www.glfusion.org/forum/viewtopic.php?showtopic=46814&topic=46818#46818.

Plugins that wish to modify the content would use `&$content` as a parameter, no change is needed for those that don't.