### PR TITLE
Can't pass empty string by reference to PLG_itemPreSave()

### DIFF
--- a/private/system/lib-plugins.php
+++ b/private/system/lib-plugins.php
@@ -720,7 +720,7 @@ function PLG_commentPreSave($uid, &$title, &$comment, $sid, $pid, $type, &$postm
 * @return string empty is no error, error message if error was encountered
 *
 */
-function PLG_itemPreSave($type, &$content)
+function PLG_itemPreSave($type, &$content = '')
 {
     global $_PLUGINS;
 

--- a/public_html/users.php
+++ b/public_html/users.php
@@ -1444,7 +1444,7 @@ function _userEmailpassword()
         $retval .= getpasswordform();
     } else {
         // Validate captcha
-        $msg = PLG_itemPreSave ('forgotpassword', '');
+        $msg = PLG_itemPreSave ('forgotpassword');
         if (!empty ($msg)) {
             COM_setMsg($msg,'error');
             echo COM_refresh ($_CONF['site_url'].'/users.php?mode=getpassword');


### PR DESCRIPTION
Unintended consequence of passing by reference, literals aren't supported. The call in lib-users.php is the only one I found that passes a literal to PLG_itemPreSave()