### PR TITLE
Fix double WHERE in polls list

### DIFF
--- a/public_html/polls/index.php
+++ b/public_html/polls/index.php
@@ -77,8 +77,8 @@ function POLLS_pollList()
                           'icon' => '', 'form_url' => '');
 
         $query_arr = array('table' => 'polltopics',
-                           'sql' => $sql = "SELECT *,UNIX_TIMESTAMP(date) AS unixdate, display "
-                                . "FROM {$_TABLES['polltopics']} WHERE 1=1",
+                           'sql' => "SELECT *,UNIX_TIMESTAMP(date) AS unixdate, display "
+                                . "FROM {$_TABLES['polltopics']}",
                            'query_fields' => array('topic'),
                            'default_filter' => COM_getPermSQL (),
                            'query' => '',


### PR DESCRIPTION
Re #385, since 29f5612ecce55eff5fda1a48b615caa332101011 the Polls plugin index.page has a double WHERE in the sql provided to ADMIN_list(). This removes the `WHERE 1=1`.