### PR TITLE
Add samesite to cookies

### DIFF
--- a/private/system/lib-security.php
+++ b/private/system/lib-security.php
@@ -1690,7 +1690,7 @@ function SEC_setCookie($name, $value, $expire = 0, $path = '', $domain = '', $se
         'secure' => $secure ? true : false,
         'httponly' => $httponly ? true : false,
         'expires' => $expire,
-        'samesite' => 'Lax',
+        'samesite' => $samesite,
     );
     $retval = @setcookie($name, $value, $options);
     return $retval;

--- a/private/system/lib-security.php
+++ b/private/system/lib-security.php
@@ -1653,10 +1653,11 @@ function SEC_checkTokenGeneral($token,$action='general',$uid=0)
 * @param string $path   the path on the server in which the cookie will be available - defaults to $_CONF['cookie_path']
 * @param string $domain the domain that the cookie is available - defaults to $_CONF['cookiedomain']
 * @param bool   $secure indicates that the cookie shoul only be transmitted over secure HTTPS connection - defaults to $_CONF['cookiesecure']
+* @param string $samesite the samesite flag setting. Allows 'Lax', 'Strict' or 'None'
 * @param bool   $httponly when true the cookie will be made accessible only through the HTTP protocol
 *
 */
-function SEC_setCookie($name, $value, $expire = 0, $path = '', $domain = '', $secure = false, $httponly = false)
+function SEC_setCookie($name, $value, $expire = 0, $path = '', $domain = '', $secure = false, $httponly = false, $samesite='Lax')
 {
     global $_CONF, $_SYSTEM;
 
@@ -1674,16 +1675,24 @@ function SEC_setCookie($name, $value, $expire = 0, $path = '', $domain = '', $se
         $domain = $_CONF['cookiedomain'];
     }
 
-    if ($secure == '') {
+    if (!in_array($samesite, array('Lax', 'Strict', 'None'))) {
+        $samesite = 'Lax';
+    }
+    if ($samesite = 'None') {
+        $secure = true;
+    } elseif ($secure == '') {
         $secure = $_CONF['cookiesecure'];
     }
 
-    if ( $httponly ) {
-        $retval = @setcookie($name, $value, $expire, $path, $domain, $secure, true);
-    } else {
-        $retval = @setcookie($name, $value, $expire, $path, $domain, $secure);
-    }
-
+    $options = array(
+        'path' => $path,
+        'domain' => $domain,
+        'secure' => $secure ? true : false,
+        'httponly' => $httponly ? true : false,
+        'expires' => $expire,
+        'samesite' => 'Lax',
+    );
+    $retval = @setcookie($name, $value, $options);
     return $retval;
 }
 

--- a/private/system/lib-security.php
+++ b/private/system/lib-security.php
@@ -1678,7 +1678,7 @@ function SEC_setCookie($name, $value, $expire = 0, $path = '', $domain = '', $se
     if (!in_array($samesite, array('Lax', 'Strict', 'None'))) {
         $samesite = 'Lax';
     }
-    if ($samesite = 'None') {
+    if ($samesite == 'None') {
         $secure = true;
     } elseif ($secure == '') {
         $secure = $_CONF['cookiesecure'];

--- a/private/system/lib-sessions.php
+++ b/private/system/lib-sessions.php
@@ -39,7 +39,14 @@ if (empty ($_CONF['cookiedomain'])) {
     }
 }
 
-session_set_cookie_params ( 0, $_CONF['cookie_path'], $_CONF['cookiedomain'], $_CONF['cookiesecure'],true);
+session_set_cookie_params(array(
+    'lifetime' => 0,
+    'path' => $_CONF['cookie_path'],
+    'domain' => $_CONF['cookiedomain'],
+    'secure' => $_CONF['cookiesecure'],
+    'httponly' => true,
+    'samesite' => 'Lax',
+));
 
 // Need to destroy any existing sessions started with session.auto_start
 if (session_id()) {
@@ -229,10 +236,10 @@ function SESS_checkRememberMe()
                 // Invalid remember settings - clear all the cookies
                 $userid = 0;
 
-                SEC_setcookie ($_CONF['cookie_name'], '', time() - 3600,
+                SEC_setCookie ($_CONF['cookie_name'], '', time() - 3600,
                                $_CONF['cookie_path'], $_CONF['cookiedomain'],
                                $_CONF['cookiesecure'],true);
-                SEC_setcookie ($_CONF['cookie_password'], '', time() - 3600,
+                SEC_setCookie ($_CONF['cookie_password'], '', time() - 3600,
                                $_CONF['cookie_path'], $_CONF['cookiedomain'],
                                $_CONF['cookiesecure'],true);
             }
@@ -285,8 +292,8 @@ function SESS_newSession($userid, $remote_ip, $lifespan)
     		if (session_id()) {
     			session_unset();
     			session_destroy();
-    		}
-            SEC_setcookie ($_CONF['cookie_session'], '', time() - 3600,
+                }
+            SEC_setCookie ($_CONF['cookie_session'], '', time() - 3600,
                            $_CONF['cookie_path'], $_CONF['cookiedomain'],
                            $_CONF['cookiesecure'],true);
         }
@@ -604,8 +611,9 @@ function SESS_completeLogin($uid, $authenticated = 1)
 
 	if (isset($_COOKIE[$_CONF['cookie_session']])) {
 		$cookie_domain = $_CONF['cookiedomain'];
-		$cookie_path   = $_CONF['cookie_path'];
-		setcookie($_COOKIE[$_CONF['cookie_session']],'', time()-42000, $cookie_path, $cookie_domain,$_CONF['cookiesecure'],true);
+                $cookie_path   = $_CONF['cookie_path'];
+                SEC_setCookie($_CONF['cookie_session'],'', time()-42000);
+                //$cookie_path, $cookie_domain,$_CONF['cookiesecure'],true);
 	}
 
     session_id($sessid);
@@ -655,7 +663,7 @@ function SESS_completeLogin($uid, $authenticated = 1)
 
     if ( $_CONF['allow_user_themes'] ) {
         // set theme cookie (or update it )
-        SEC_setcookie ($_CONF['cookie_theme'], $_USER['theme'], time() + 31536000,
+        SEC_setCookie ($_CONF['cookie_theme'], $_USER['theme'], time() + 31536000,
                        $_CONF['cookie_path'], $_CONF['cookiedomain'],
                        $_CONF['cookiesecure'],true);
     }


### PR DESCRIPTION
To avoid warnings like this:
`Cookie “glf_language” will be soon rejected because it has the “SameSite” attribute set to “None” or an invalid value, without the “secure” attribute. To know more about the “SameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite`

I haven't figured out the javascript setting cookieconsent in the privacy plugin yet, but it has the same issue.