### PR TITLE
Handle empty form vars from usersettings page

### DIFF
--- a/public_html/usersettings.php
+++ b/public_html/usersettings.php
@@ -1724,10 +1724,26 @@ function savepreferences($A)
         }
     }
 
-    $TIDS  = @array_values($A['topics']);
-    $AIDS  = @array_values($A['selauthors']);
-    $BOXES = @array_values($A['blocks']);
-    $ETIDS = @array_values($A['dgtopics']);
+    if (isset($A['topics']) && is_array($A['topics'])) {
+        $TIDS  = @array_values($A['topics']);
+    } else {
+        $TIDS = array();
+    }
+    if (isset($A['selauthors']) && is_array($A['selauthors'])) {
+        $AIDS  = @array_values($A['selauthors']);
+    } else {
+        $AIDS = array();
+    }
+    if (isset($A['blocks']) && is_array($A['blocks'])) {
+        $BOXES = @array_values($A['blocks']);
+    } else {
+        $BOXES = array();
+    }
+    if (isset($A['dgtopics']) && is_array($A['dgtopics'])) {
+        $ETIDS = @array_values($A['dgtopics']);
+    } else {
+        $ETIDS = array();
+    }
     $allowed_etids = USER_buildTopicList ();
     $AETIDS = explode (' ', $allowed_etids);
 
@@ -1837,10 +1853,12 @@ function savepreferences($A)
 
     DB_save($_TABLES['usercomment'],'uid,commentmode,commentorder,commentlimit',"{$_USER['uid']},'{$A['commentmode']}','{$A['commentorder']}',".(int) $A['commentlimit']);
 
-    $subscription_deletes  = @array_values($A['subdelete']);
-    if ( is_array($subscription_deletes) ) {
-        foreach ( $subscription_deletes AS $subid ) {
-            DB_delete($_TABLES['subscriptions'],'sub_id',(int) $subid);
+    if (isset($A['subdelete']) && is_array($A['subdelete'])) {
+        $subscription_deletes  = @array_values($A['subdelete']);
+        if ( is_array($subscription_deletes) ) {
+            foreach ( $subscription_deletes AS $subid ) {
+                DB_delete($_TABLES['subscriptions'],'sub_id',(int) $subid);
+            }
         }
     }
     $c = Cache::getInstance()->deleteItemsByTags(array('story','menu','userdata'));


### PR DESCRIPTION
When saving user preferences, some arrays like Topic and Author filters may be empty or undefined if not configured to allow user editing.