### PR TITLE
Forum centerblock to check the template from the layout first

### DIFF
--- a/private/plugins/forum/functions.inc
+++ b/private/plugins/forum/functions.inc
@@ -1073,7 +1073,14 @@ function plugin_centerblock_forum ($where = 1, $page = 1, $topic = '')
             return $retval;
         }
 
-        $block = new Template($_CONF['path'] . 'plugins/forum/templates/blocks/');
+	// Check whether the centerblock template exists in the layout folder
+	$common_tpl_dir = $_CONF['path'].'plugins/forum/templates/blocks/';
+	$layout_tpl_dir = $_CONF['path_layout'].'plugins/forum/blocks/';
+
+	$templatepath = file_exists($layout_tpl_dir.'centerblock.thtml')
+			? $layout_tpl_dir : $common_tpl_dir;
+
+        $block = new Template($templatepath);
         $block->set_file ('block','centerblock.thtml');
         $block->set_var (array(
                 'phpself'       => $_CONF['site_url'] .'/index.php',


### PR DESCRIPTION
A small change to Forum plugin so that the centerblock will try to get the template from under the layout first. 

Otherwise the theme couldn't theme the centerblock while it should.