### PR TITLE
Enable date-only and time-only pickers

### DIFF
--- a/public_html/javascript/addons/datetime/datetimepicker.js
+++ b/public_html/javascript/addons/datetime/datetimepicker.js
@@ -4,6 +4,14 @@ $(document).ready(function(){
 		var id = $(this).attr('id');
 		datetimepicker_popupcal(id);
 	});
+	$('.datepicker').each(function(i, obj) {
+		var id = $(this).attr('id');
+		datetimepicker_datepicker(id);
+	});
+	$('.timepicker').each(function(i, obj) {
+		var id = $(this).attr('id');
+		datetimepicker_timepicker(id);
+	});
 });
 function datetimepicker_popupcal( selector ) {
 	var currentDT = $("#"+selector).val();
@@ -12,5 +20,26 @@ function datetimepicker_popupcal( selector ) {
 		lazyInit: true,
 		value:currentDT,
 		format:'Y-m-d H:i',
+	});
+}
+function datetimepicker_datepicker( selector ) {
+	var currentDT = $("#"+selector).val();
+	$('#'+selector).val( currentDT );
+	$('#'+selector).datetimepicker({
+		lazyInit: true,
+		value:currentDT,
+		format:'Y-m-d',
+		timepicker: false,
+	});
+}
+function datetimepicker_timepicker( selector ) {
+	var currentDT = $("#"+selector).val();
+	$('#'+selector).val( currentDT );
+	$('#'+selector).datetimepicker({
+		lazyInit: true,
+		value:currentDT,
+		format:'H:i',
+		datepicker: false,
+		step: 15,
 	});
 }


### PR DESCRIPTION
I have a few cases where I need separate date and time selectors, such as Evlist, or even no time selector at all. This enables `class="datepicker"` and `class="timepicker"` in addition to "popupcal" to use the existing xdsoft datetimepicker.