### PR TITLE
Fix typo after re-enabling SEC_checkToken()

### DIFF
--- a/public_html/filemgmt/submit.php
+++ b/public_html/filemgmt/submit.php
@@ -201,7 +201,7 @@ if (Filemgmt\Download::canSubmit()) {
         exit;
     }
 
-    if ( isset($_POST['submit'])) && SEC_checkToken()){
+    if ( isset($_POST['submit']) && SEC_checkToken() ){
 
         if (!COM_isAnonUser() ) {
             $submitter = (int) $_USER['uid'];


### PR DESCRIPTION
Left a parenthesis in the wrong place when uncommenting `SEC_checkToken() ` after testing.  Oops.