### PR TITLE
Redirect back to origin after admin save, better messages

### DIFF
--- a/private/plugins/filemgmt/classes/Models/Status.class.php
+++ b/private/plugins/filemgmt/classes/Models/Status.class.php
@@ -30,4 +30,5 @@ class Status
     const UPL_NODEMO = 4;   // uploads disabled in demo mode
     const UPL_PENDING = 5;  // success, pending approval
     const UPL_MISSING = 6;  // missing fields
+    const UPL_UPDATED = 7;  // file updated, no new file uploaded
 }

--- a/private/plugins/filemgmt/language/czech_utf-8.php
+++ b/private/plugins/filemgmt/language/czech_utf-8.php
@@ -129,6 +129,7 @@ $LANG_FILEMGMT = array(
     'category' => 'Category',
     'err_req_fields' => 'Some required fields were not supplied',
     'go_back' => 'Go Back',
+    'err_demomode' => 'Uploads are disabled in demo mode',
 );
 
 $LANG_FILEMGMT_ERRORS = array(

--- a/private/plugins/filemgmt/language/dutch_utf-8.php
+++ b/private/plugins/filemgmt/language/dutch_utf-8.php
@@ -129,6 +129,7 @@ $LANG_FILEMGMT = array(
     'category' => 'Category',
     'err_req_fields' => 'Some required fields were not supplied',
     'go_back' => 'Go Back',
+    'err_demomode' => 'Uploads are disabled in demo mode',
 );
 
 $LANG_FILEMGMT_ERRORS = array(

--- a/private/plugins/filemgmt/language/english_utf-8.php
+++ b/private/plugins/filemgmt/language/english_utf-8.php
@@ -129,6 +129,7 @@ $LANG_FILEMGMT = array(
     'category' => 'Category',
     'err_req_fields' => 'Some required fields were not supplied',
     'go_back' => 'Go Back',
+    'err_demomode' => 'Uploads are disabled in demo mode',
 );
 
 $LANG_FILEMGMT_ERRORS = array(

--- a/private/plugins/filemgmt/language/finnish_utf-8.php
+++ b/private/plugins/filemgmt/language/finnish_utf-8.php
@@ -129,6 +129,7 @@ $LANG_FILEMGMT = array(
     'category' => 'Category',
     'err_req_fields' => 'Some required fields were not supplied',
     'go_back' => 'Go Back',
+    'err_demomode' => 'Uploads are disabled in demo mode',
 );
 
 $LANG_FILEMGMT_ERRORS = array(

--- a/private/plugins/filemgmt/language/french_canada_utf-8.php
+++ b/private/plugins/filemgmt/language/french_canada_utf-8.php
@@ -129,6 +129,7 @@ $LANG_FILEMGMT = array(
     'category' => 'Category',
     'err_req_fields' => 'Some required fields were not supplied',
     'go_back' => 'Go Back',
+    'err_demomode' => 'Uploads are disabled in demo mode',
 );
 
 $LANG_FILEMGMT_ERRORS = array(

--- a/private/plugins/filemgmt/language/german_utf-8.php
+++ b/private/plugins/filemgmt/language/german_utf-8.php
@@ -127,6 +127,7 @@ $LANG_FILEMGMT = array(
     'category' => 'Category',
     'err_req_fields' => 'Some required fields were not supplied',
     'go_back' => 'Go Back',
+    'err_demomode' => 'Uploads are disabled in demo mode',
 );
 
 $LANG_FILEMGMT_ERRORS = array(

--- a/private/plugins/filemgmt/language/polish_utf-8.php
+++ b/private/plugins/filemgmt/language/polish_utf-8.php
@@ -129,6 +129,7 @@ $LANG_FILEMGMT = array(
     'category' => 'Category',
     'err_req_fields' => 'Some required fields were not supplied',
     'go_back' => 'Go Back',
+    'err_demomode' => 'Uploads are disabled in demo mode',
 );
 
 $LANG_FILEMGMT_ERRORS = array(

--- a/private/plugins/filemgmt/language/spanish_colombia_utf-8.php
+++ b/private/plugins/filemgmt/language/spanish_colombia_utf-8.php
@@ -129,6 +129,7 @@ $LANG_FILEMGMT = array(
     'category' => 'Category',
     'err_req_fields' => 'Some required fields were not supplied',
     'go_back' => 'Go Back',
+    'err_demomode' => 'Uploads are disabled in demo mode',
 );
 
 $LANG_FILEMGMT_ERRORS = array(

--- a/private/plugins/filemgmt/language/turkish_utf-8.php
+++ b/private/plugins/filemgmt/language/turkish_utf-8.php
@@ -129,6 +129,7 @@ $LANG_FILEMGMT = array(
     'category' => 'Category',
     'err_req_fields' => 'Some required fields were not supplied',
     'go_back' => 'Go Back',
+    'err_demomode' => 'Uploads are disabled in demo mode',
 );
 
 $LANG_FILEMGMT_ERRORS = array(

--- a/private/plugins/filemgmt/templates/admin/mod_file.thtml
+++ b/private/plugins/filemgmt/templates/admin/mod_file.thtml
@@ -4,6 +4,7 @@
     <form id="filemgmt_mod_file" class="uk-form uk-form-horizontal" method="post" enctype="multipart/form-data" action="{site_admin_url}/plugins/filemgmt/index.php">
         <input type="hidden" name="lid" value="{lid}" />
 		<input type="hidden" name="redirect" value="{redirect}" />
+		<input type="hidden" name="redirect_url" value="{redirect_url}" />
 {!if !newfile}
 		<div class="uk-form-row uk-margin">
 			<label class="uk-form-label">{lang_file_id}</label>

--- a/public_html/admin/plugins/filemgmt/index.php
+++ b/public_html/admin/plugins/filemgmt/index.php
@@ -92,13 +92,16 @@ case "saveDownload":
     $status = Filemgmt\Download::getInstance($_POST['lid'])->Save($_POST);
     switch ($status) {
     case Status::UPL_NODEMO:
-        COM_setMsg('Uploads are disabled in demo mode', 'error');
+        COM_setMsg($LANG_FILEMGMT['err_demomode'], 'error');
         break;
     case Status::UPL_DUPFILE:
         COM_setMsg(_MD_NEWDLADDED_DUPFILE, 'error');
         break;
     case Status::UPL_DUPSNAP:
         COM_setMsg(_MD_NEWDLADDED_DUPSNAP, 'error');
+        break;
+    case Status::UPL_UPDATED:
+        COM_setMsg(_MD_DLUPDATED);
         break;
     case Status::OK:
         COM_setMsg(_MD_NEWDLADDED);
@@ -108,7 +111,11 @@ case "saveDownload":
         COM_setMsg(_MD_ERRUPLOAD, 'error');
         break;
     }
-    COM_refresh($_FM_CONF['admin_url'] . '/index.php');
+    if (isset($_POST['redirect_url'])) {
+        COM_refresh($_POST['redirect_url']);
+    } else {
+        COM_refresh($_FM_CONF['admin_url'] . '/index.php');
+    }
     break;
 case "listBrokenLinks":
     $content .= Filemgmt\BrokenLink::adminList();


### PR DESCRIPTION
Redirects back to the original page after admin editing from admin list or file listing.
Show "File has been updated" instead of "File has been uploaded" if no upload was made (by admin)