### PR TITLE
Make sure logged-in users is added if uid > 1

### DIFF
--- a/private/system/classes/group.class.php
+++ b/private/system/classes/group.class.php
@@ -142,7 +142,6 @@ class Group
         }
 
         $data = $stmt->fetchAll(Database::ASSOCIATIVE);
-
         $stmt->closeCursor();
         if (count($data) < 1) {
             $data = array();
@@ -203,7 +202,6 @@ class Group
         // Not in cache? First get directly-assigned memberships, then
         // all inherited ones.
         $groups = self::getAssigned($uid);
-
         $cTotalGroups = count($groups);
 //        Log::write('system',Log::DEBUG,sprintf("%s::%s got %d assigned groups.",__CLASS__,__FUNCTION__,$cTotalGroups));
 
@@ -247,13 +245,10 @@ class Group
             }
         }
         $groups['All Users'] = 2;
-        if (!COM_isAnonUser()) {
+        if ($uid > 1) {
             $groups['Logged-in Users'] = 13;
         }
 
-        if (count($groups) == 0) {
-            $groups = array('All Users' => 2);
-        }
         ksort($groups);
         $runonce[$uid] = $groups;
         Cache::getInstance()->set($cache_key, $groups, array('groups', 'user_' . $uid));


### PR DESCRIPTION
For functions like runScheduledTask, group memberships need to be checked for specific users other than the one logged in. This makes sure Logged-In Users is added to the group list if the user ID is > 1, instead of checking if the current visitor is anonymous.

Also, checking for an empty $groups array is redundant since "All Users" was added previously.