### PR TITLE
Add fields to ical feed, pass feed info record to plugins

### DIFF
--- a/private/system/lib-plugins.php
+++ b/private/system/lib-plugins.php
@@ -2336,10 +2336,11 @@ function PLG_getFeedNames($plugin)
 * @param    string   update_data   information for later up-to-date checks
 * @param    string   feedType      The type of feed (RSS/Atom etc)
 * @param    string   feedVersion   The version info of the feed.
+* @param    array    $A            The full feed record from the syndication table
 * @return   array                  content of feed
 *
 */
-function PLG_getFeedContent($plugin, $feed, &$link, &$update_data, $feedType, $feedVersion)
+function PLG_getFeedContent($plugin, $feed, &$link, &$update_data, $feedType, $feedVersion, $A=array())
 {
     global $_PLUGINS;
 
@@ -2348,7 +2349,7 @@ function PLG_getFeedContent($plugin, $feed, &$link, &$update_data, $feedType, $f
     if ($plugin == 'custom') {
         $function = 'CUSTOM_getfeedcontent';
         if (function_exists($function)) {
-            $content = $function($feed, $link, $update_data, $feedType, $feedVersion);
+            $content = $function($feed, $link, $update_data, $feedType, $feedVersion, $A);
         }
     } else {
         $pluginTypes = array_merge(array('article','comment'), $_PLUGINS);
@@ -2356,7 +2357,7 @@ function PLG_getFeedContent($plugin, $feed, &$link, &$update_data, $feedType, $f
         if (in_array ($plugin, $pluginTypes)) {
             $function = 'plugin_getfeedcontent_' . $plugin;
             if (function_exists ($function)) {
-                $content = $function ($feed, $link, $update_data, $feedType, $feedVersion);
+                $content = $function ($feed, $link, $update_data, $feedType, $feedVersion, $A);
             }
         }
     }

--- a/private/system/lib-syndication.php
+++ b/private/system/lib-syndication.php
@@ -573,6 +573,12 @@ function SYND_updateFeediCal( $A )
 
         $vCalendar = new \Eluceo\iCal\Component\Calendar($_CONF['site_url']);
         $vCalendar->setMethod('PUBLISH');
+        if (!empty($A['title'])) {
+            $vCalendar->setName($A['title']);
+        }
+        if (!empty($A['description'])) {
+            $vCalendar->setDescription($A['description']);
+        }
 
         if ( !empty( $A['filename'] )) {
             $filename = $A['filename'];

--- a/private/system/lib-syndication.php
+++ b/private/system/lib-syndication.php
@@ -509,7 +509,7 @@ function SYND_updateFeed( $fid )
         $rss->syndicationURL = SYND_getFeedUrl( $filename );
         $rss->copyright = 'Copyright ' . strftime( '%Y' ) . ' '.$_CONF['site_name'];
 
-        $content = PLG_getFeedContent($A['type'], $fid, $link, $data, $format[0], $format[1]);
+        $content = PLG_getFeedContent($A['type'], $fid, $link, $data, $format[0], $format[1], $A);
 
         if ( is_array($content) ) {
             foreach ( $content AS $feedItem ) {
@@ -531,6 +531,7 @@ function SYND_updateFeed( $fid )
                 $rss->addItem($item);
             }
         }
+
         if (empty($link)) {
             $link = $_CONF['site_url'];
         }
@@ -571,6 +572,7 @@ function SYND_updateFeediCal( $A )
         $format = explode( '-', $A['format'] );
 
         $vCalendar = new \Eluceo\iCal\Component\Calendar($_CONF['site_url']);
+        $vCalendar->setMethod('PUBLISH');
 
         if ( !empty( $A['filename'] )) {
             $filename = $A['filename'];
@@ -580,7 +582,7 @@ function SYND_updateFeediCal( $A )
 //            $filename = substr( $_CONF['rdf_file'], $pos + 1 );
         }
 
-        $content = PLG_getFeedContent($A['type'], $A['fid'], $link, $data, $format[0], $format[1]);
+        $content = PLG_getFeedContent($A['type'], $A['fid'], $link, $data, $format[0], $format[1], $A);
 
         if ( is_array($content) ) {
             foreach ( $content AS $feedItem ) {
@@ -593,6 +595,11 @@ function SYND_updateFeediCal( $A )
                         case 'date' :
                             $date = is_numeric($value) ? date('c', $value) : $value;
                             $vEvent->setCreated(new \DateTime($date));
+                            break;
+
+                        case 'modified' :
+                            $date = is_numeric($value) ? date('c', $value) : $value;
+                            $vEvent->setModified(new \DateTime($date));
                             break;
 
                         case 'title' :
@@ -625,6 +632,14 @@ function SYND_updateFeediCal( $A )
 
                         case 'allday' :
                             $vEvent->setNoTime($value);
+                            break;
+
+                        case 'status' :
+                            $vEvent->setStatus($value);
+                            break;
+
+                        case 'sequence':
+                            $vEvent->setSequence($value);
                             break;
 
                         case 'rrule' :


### PR DESCRIPTION
This adds a couple of standard headers to ICS feeds, and also passes the entire record from the syndication table to plugins so they can access the topic and other information. Currently there are a lot of DB calls by each plugin to get the feed topic, description and other info.