### PR TITLE
Disabled autocomplete for TOTP (2FA) code input fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Replaced all old style Cache calls to new Cache class interface
 - FileMgmt Admin screens now adhere to glFusion UI standards
 - Password is required to change any user profile fields
+- Disabled autocomplete for TOTP (2FA) code input fields
 
 ### Depreciated
 

--- a/public_html/layout/cms/preferences/tfa-enroll.thtml
+++ b/public_html/layout/cms/preferences/tfa-enroll.thtml
@@ -20,7 +20,7 @@
 
 <div class="uk-form-row">
 	<label >{lang_auth_code}</label>
-	<input type="text" id="twofactorverify" name="twofactorverify" autofocus>&nbsp;
+	<input type="text" id="twofactorverify" name="twofactorverify" autocomplete="off" autofocus>&nbsp;
 	<button id="tfa-verify" class="uk-button uk-button-success">{lang_verify}</button>
 	<input type="hidden" id="tfasecret" name="tfasecret" value="{tfa-secret}">
 	<input type="hidden" id="{token_name}" name="{token_name}" value="{token_value}">

--- a/public_html/layout/cms/users/tfa-entry-form.thtml
+++ b/public_html/layout/cms/users/tfa-entry-form.thtml
@@ -10,7 +10,7 @@
 				<input type="hidden" name="{token_name}" value="{token_value}">
 				<input type="hidden" name="mode" value="tfa">
 				<div class="uk-form-row">
-					<input class="uk-width-1-1 uk-form-large" type="text" placeholder="{lang_auth_code}" id="tfacode" name="tfacode" value="" required autofocus>
+					<input class="uk-width-1-1 uk-form-large" type="text" placeholder="{lang_auth_code}" id="tfacode" name="tfacode" value="" autocomplete="off" required autofocus>
 				</div>
 				<div class="uk-form-row uk-margin">
 					<button type="submit" id="loginbutton" class="uk-width-1-1 uk-button uk-button-success uk-button-large">{lang_verify}</button>


### PR DESCRIPTION
Browsers should not remember previously entered TOTP codes

I'm not sure what the cherry-picking process for glFusion, is but I'd love to see this get merged back to master/1.7 if possible (let me know if I should open another PR)