### PR TITLE
Revision to PR 415, adding an option for ad-hoc landing page

### DIFF
--- a/private/language/czech_utf-8.php
+++ b/private/language/czech_utf-8.php
@@ -2765,6 +2765,7 @@ $LANG_confignames['Core'] = array(
     'commentsubmission' => 'Queue Comment Submissions',
     'passwordspeedlimit' => 'Password Speed Limit',
     'login_attempts' => 'Max. Login Attempts',
+    'login_landing' => 'Vstupní vstupní stránka',
     'login_speedlimit' => 'Login Speed Limit',
     'user_html' => 'User HTML',
     'admin_html' => 'Admin HTML',

--- a/private/language/dutch_utf-8.php
+++ b/private/language/dutch_utf-8.php
@@ -2765,6 +2765,7 @@ $LANG_confignames['Core'] = array(
     'commentsubmission' => 'Zet Ingezonden Reacties in Wachtrij',
     'passwordspeedlimit' => 'Snelheidslimiet Wachtwoord',
     'login_attempts' => 'Max. aantal Aanmeldings Pogingen',
+    'login_landing' => 'Bestemmingspagina inloggen',
     'login_speedlimit' => 'Snelheidslimiet van Aanmelden',
     'user_html' => 'Gebruiker HTML',
     'admin_html' => 'Beheerder HTML',

--- a/private/language/english_utf-8.php
+++ b/private/language/english_utf-8.php
@@ -2765,6 +2765,7 @@ $LANG_confignames['Core'] = array(
     'commentsubmission' => 'Queue Comment Submissions',
     'passwordspeedlimit' => 'Password Speed Limit',
     'login_attempts' => 'Max. Login Attempts',
+    'login_landing' => 'Login Landing Page',
     'login_speedlimit' => 'Login Speed Limit',
     'user_html' => 'User HTML',
     'admin_html' => 'Admin HTML',

--- a/private/language/finnish_utf-8.php
+++ b/private/language/finnish_utf-8.php
@@ -2765,6 +2765,7 @@ $LANG_confignames['Core'] = array(
     'commentsubmission' => 'Kommenttien Lähetysjono',
     'passwordspeedlimit' => 'Salasana Nopeusrajoitus',
     'login_attempts' => 'Max. Kirjautumis Yrityksiä',
+    'login_landing' => 'Kirjautumisen aloitussivu',
     'login_speedlimit' => 'Kirjautumis Nopeusrajoitus',
     'user_html' => 'Käyttäjä HTML',
     'admin_html' => 'Admin HTML',

--- a/private/language/french_canada_utf-8.php
+++ b/private/language/french_canada_utf-8.php
@@ -2765,6 +2765,7 @@ $LANG_confignames['Core'] = array(
     'commentsubmission' => 'Queue Comment Submissions',
     'passwordspeedlimit' => 'Password Speed Limit',
     'login_attempts' => 'Max. Login Attempts',
+    'login_landing' => 'Page de destination de connexion',
     'login_speedlimit' => 'Login Speed Limit',
     'user_html' => 'User HTML',
     'admin_html' => 'Admin HTML',

--- a/private/language/german_utf-8.php
+++ b/private/language/german_utf-8.php
@@ -2765,6 +2765,7 @@ $LANG_confignames['Core'] = array(
     'commentsubmission' => 'Moderation von Kommentaren',
     'passwordspeedlimit' => 'Passwort Wartezeit in Sek.',
     'login_attempts' => 'Max. Anmeldeversuche',
+    'login_landing' => 'Login-Landingpage',
     'login_speedlimit' => 'Anmeldung Wartezeit in Sek.',
     'user_html' => 'Erlaubtes Benutzer HTML',
     'admin_html' => 'Erlaubtes Admin HTML',

--- a/private/language/polish_utf-8.php
+++ b/private/language/polish_utf-8.php
@@ -2769,6 +2769,7 @@ $LANG_confignames['Core'] = array(
     'commentsubmission' => 'Przesyłanie komentarzy do kolejki',
     'passwordspeedlimit' => 'Limit',
     'login_attempts' => 'Ilość prób logowania',
+    'login_landing' => 'Strona docelowa logowania',
     'login_speedlimit' => 'Ograniczenie czasu logowania',
     'user_html' => 'HTML użytkownika',
     'admin_html' => 'Admin HTML',

--- a/private/language/spanish_colombia_utf-8.php
+++ b/private/language/spanish_colombia_utf-8.php
@@ -2765,6 +2765,7 @@ $LANG_confignames['Core'] = array(
     'commentsubmission' => 'Cola de Comentario enviados',
     'passwordspeedlimit' => 'Espera para reenvío de Contraseña',
     'login_attempts' => 'Máximo de intentos de Autenticación',
+    'login_landing' => 'Página de inicio de sesión',
     'login_speedlimit' => 'Espera después intentos fallidos de Autenticación',
     'user_html' => 'User HTML',
     'admin_html' => 'Admin HTML',

--- a/private/language/turkish_utf-8.php
+++ b/private/language/turkish_utf-8.php
@@ -2765,6 +2765,7 @@ $LANG_confignames['Core'] = array(
     'commentsubmission' => 'Queue Comment Submissions',
     'passwordspeedlimit' => 'Password Speed Limit',
     'login_attempts' => 'Max. Login Attempts',
+    'login_landing' => 'Giriş Sayfası',
     'login_speedlimit' => 'Login Speed Limit',
     'user_html' => 'User HTML',
     'admin_html' => 'Admin HTML',

--- a/private/sql/core_config_data.php
+++ b/private/sql/core_config_data.php
@@ -2004,6 +2004,17 @@ $coreConfigData = array(
     	'group' => 'Core'
     ),
     array(
+    	'name' => 'login_landing',
+    	'default_value' => '/index.php',
+    	'type' => 'text',
+    	'subgroup' => 4,
+    	'fieldset' => 4,
+    	'selection_array' => NULL,
+    	'sort' => 140,
+    	'set' => TRUE,
+    	'group' => 'Core'
+    ),
+    array(
     	'name' => 'fs_user_submission',
     	'default_value' => NULL,
     	'type' => 'fieldset',

--- a/private/system/lib-security.php
+++ b/private/system/lib-security.php
@@ -2150,6 +2150,9 @@ function SEC_loginForm($use_options = array())
 
         // action
         'form_action' => $_CONF['site_url'].'/users.php',
+
+        // landing page after successful login
+        'login_landing' => '',
     );
 
     $options = array_merge($default_options, $use_options);
@@ -2220,10 +2223,16 @@ function SEC_loginForm($use_options = array())
             $services .= $loginform->finish($loginform->get_var('output'));
         }
     }
+
+    if ($options['login_landing']) {
+        $options['hidden_fields'] .= '<input type="hidden" name="login_landing" value="' .
+            $options['login_landing'] . '" />' . LB;
+    }
+
     if (! empty($options['hidden_fields'])) {
         // allow caller to (ab)use {services} for hidden fields
         $services .= $options['hidden_fields'];
-        $loginform->set_var('hidden_fields',$options['hidden_fields']);
+        //$loginform->set_var('hidden_fields',$options['hidden_fields']);
     }
     $loginform->set_var('services', $services);
 

--- a/public_html/docs/english/config.html
+++ b/public_html/docs/english/config.html
@@ -1013,6 +1013,11 @@
 					<dd>How many seconds have to pass before another login attempt can be made after <b>Max Login Attempts</b> (see above) login attempts have failed. </dd>
 				</dl>
 
+				<dl id="desc_login_landing">
+                  <dt>Login Landing Page</dt>
+                  <dd>The default URL to display upon a successful login. The URL is relative to $_CONF['site_url'].</dd>
+                </dl>
+
 				<h2>User Submission</h2>
 
 				<dl id="desc_disable_new_user_registration">

--- a/public_html/users.php
+++ b/public_html/users.php
@@ -1011,6 +1011,11 @@ function loginform ($hide_forgotpw_link = false, $statusmode = -1)
         'hide_forgotpw_link' => $hide_forgotpw_link,
         'form_action'        => $_CONF['site_url'].'/users.php',
     );
+    if (isset($_POST['login_landing'])) {
+        $options['login_landing'] = $_POST['login_landing'];
+    } elseif (isset($_GET['landing'])) {
+        $options['login_landing'] = $_GET['landing'];
+    }
 
     if ($statusmode == USER_ACCOUNT_DISABLED) {
         $options['title']   = $LANG04[114]; // account disabled
@@ -1856,6 +1861,16 @@ switch ($mode) {
             COM_resetSpeedlimit('login');
 
             // we are now fully logged in, let's see if there is someplace we need to go....
+            // First, check for a landing page supplied by the form or global config
+            foreach (array($_POST, $_CONF) as $A) {
+                if (isset($A['login_landing']) && !empty($A['login_landing'])) {
+                    if ($A['login_landing'][0] != '/') {
+                        $A['login_landing'] = '/' . $A['login_landing'];
+                    }
+                    COM_refresh($_CONF['site_url'] . $A['login_landing']);
+                }
+            }
+
             if ( SESS_isSet('login_referer') ) {
                 $_SERVER['HTTP_REFERER'] = SESS_getVar('login_referer');
                 SESS_unSet('login_referer');


### PR DESCRIPTION
This is a revision to PR 415, to allow for an ad-hoc login_landing setting in addition to a default one in $_CONF. This will allos a plugin to present a login-required button that redirects back to itself after a successful login.