### PR TITLE
Fix badge table creation when InnoDB is not enabled

### DIFF
--- a/public_html/admin/install/dvlpupdate.php
+++ b/public_html/admin/install/dvlpupdate.php
@@ -1336,12 +1336,11 @@ function glfusion_210()
       UNIQUE KEY `bg_name` (`bg_name`),
       KEY `orderby` (`bg_order`)
     ) ENGINE=MyISAM";
-    if ($use_innodb) {
-        $statements = count($_SQL);
-        for ($i = 0; $i < $statements; $i++) {
-            $_SQL[$i] = str_replace('MyISAM', 'InnoDB', $_SQL[$i]);
-            DB_query($_SQL[$i], 1);
+    foreach ($_SQL AS $sql) {
+        if ($use_innodb) {
+            $sql = str_replace('MyISAM', 'InnoDB', $sql);
         }
+        DB_query($sql,1);
     }
 
     // Only add badge records if creating the table.

--- a/public_html/admin/install/include/install.lib.php
+++ b/public_html/admin/install/include/install.lib.php
@@ -1773,12 +1773,11 @@ function INST_doDatabaseUpgrades($current_fusion_version, $use_innodb = false)
               KEY `orderby` (`bg_order`)
             ) ENGINE=MyISAM";
 
-            if ($use_innodb) {
-                $statements = count($_SQL);
-                for ($i = 0; $i < $statements; $i++) {
-                    $_SQL[$i] = str_replace('MyISAM', 'InnoDB', $_SQL[$i]);
-                    DB_query($_SQL[$i], 1);
+            foreach ($_SQL AS $sql) {
+                if ($use_innodb) {
+                    $sql = str_replace('MyISAM', 'InnoDB', $sql);
                 }
+                DB_query($sql,1);
             }
 
             // Only add badge records if creating the table.


### PR DESCRIPTION
DB_query to create tables is inside the `if $innodb` condition, so they're not being created if InnoDB is not used.