### PR TITLE
Force cron

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -470,7 +470,7 @@ function _cronSchedule() {
     if ( !isset($_VARS['last_maint_run'] ) || $_VARS['last_maint_run'] == '') {
         $_VARS['last_maint_run'] = 0;
     }
-    if ((($_VARS['last_maint_run'] + 600 ) <= time())) {
+    if ($_CONF['cron_schedule_interval'] > 0 && (($_VARS['last_maint_run'] + 600 ) <= time())) {
         return '<img alt="" src="'.$_CONF['site_url'].'/cron.php?id='.time().'" height="1" width="2" />';
     } else {
         return '';


### PR DESCRIPTION
This is just a thought, but there are some benefits to running cron.php via an actual cron job or scheduled task.
- The time when the job is run is more deterministic for low-volume sites
- Some random guest isn't penalized for hitting the site when the job is scheduled as jobs can take some time.

This allows cron.php to be forced to run if run from the CLI, ignoring the last_run values. It also completely disables cron in index.php if the scheduled interval is "0".