### PR TITLE
Fix email validation, max timestamp

### DIFF
--- a/private/classes/Notifier.php
+++ b/private/classes/Notifier.php
@@ -55,7 +55,7 @@ abstract class Notifier
 
     /** Expiration timestamp, if supported.
      * @var integer */
-    protected $exp_ts = 2208988799;     // 2039-12-31 23:59:59 UTC
+    protected $exp_ts = 2145916799;     // 2037-12-31 23:59:59 UTC
 
 
     /**

--- a/private/classes/Notifiers/Email.php
+++ b/private/classes/Notifiers/Email.php
@@ -228,7 +228,7 @@ class Email extends \glFusion\Notifier
                         $email = $to;
                         $name = '';
                     }
-                    if ( filter_var($to['email'], FILTER_VALIDATE_EMAIL) ) {
+                    if ( filter_var($email, FILTER_VALIDATE_EMAIL) ) {
                         $mail->addAddress($email,$name);
                         $queued++;
                     }


### PR DESCRIPTION
Fixes the variable used for address validation, and sets the maximum timestamp where supported.