### PR TITLE
Add blank icon option to FieldList to help with spacing

### DIFF
--- a/private/classes/FieldList.php
+++ b/private/classes/FieldList.php
@@ -721,5 +721,27 @@ class FieldList
         return $t->finish($t->get_var('output'));
     }
 
+    /**
+     * Create a blank icon to help with spacing.
+     */
+    public static function blank($args=array())
+    {
+        $t = self::init();
+        $t->set_block('up','field-blank');
+
+        if (isset($args['attr']) && is_array($args['attr'])) {
+            $t->set_block('field-blank','attr','attributes');
+            foreach($args['attr'] AS $name => $value) {
+                $t->set_var(array(
+                    'name' => $name,
+                    'value' => $value)
+                );
+                $t->parse('attributes','attr',true);
+            }
+        }
+        $t->parse('output','field-blank');
+        return $t->finish($t->get_var('output'));
+    }
+
 }
 ?>

--- a/public_html/layout/cms/admin/lists/fieldlist.thtml
+++ b/public_html/layout/cms/admin/lists/fieldlist.thtml
@@ -228,4 +228,12 @@
     ><i class="uk-icon uk-icon-hover uk-icon-justifiy uk-icon-arrow-circle-up uk-text-success"></i></a>
 <!-- END field-update -->
 
+<!-- BEGIN field-blank -->
+    <i class="uk-icon uk-icon-justify"
+	<!-- BEGIN attr -->
+        {name}="{value}"
+    <!-- END attr -->
+    ></i></a>
+<!-- END field-blank -->
+
 {# end admin fields #}


### PR DESCRIPTION
For consistency in admin lists, this creates a blank icon for spacing instead of using blank.gif. Likely to be used with the up/down reordering links.