### PR TITLE
Fix #560, never show output for blocks with no content

### DIFF
--- a/public_html/lib-common.php
+++ b/public_html/lib-common.php
@@ -2890,12 +2890,14 @@ function COM_formatBlock( $A, $noboxes = false)
         if (( $A['allow_autotags'] == 1 ) && ( $A['type'] == 'normal' )) {
             $blockcontent = PLG_replaceTags( $blockcontent,'glfusion','block' );
         }
-        $blockcontent = str_replace( array( '<?', '?>' ), '', $blockcontent );
+        $blockcontent = str_replace( array( '<'.'?', '?'.'>' ), '', $blockcontent );
 
-        $retval .= COM_startBlock( $A['title'], $A['help'],
+        if (!empty($blockcontent)) {
+            $retval .= COM_startBlock( $A['title'], $A['help'],
                        COM_getBlockTemplate( $A['name'], 'header', $position ), $A['name'] )
                 . $blockcontent . PHP_EOL
                 . COM_endBlock( COM_getBlockTemplate( $A['name'], 'footer', $position ));
+        }
     }
 
     return $retval;


### PR DESCRIPTION
Updating from the previous PR. There's really no reason to ever show blocks with completely empty content.