### PR TITLE
Fix POST var used for batch user actions

### DIFF
--- a/public_html/admin/user.php
+++ b/public_html/admin/user.php
@@ -2449,7 +2449,7 @@ function USER_handlePhotoUpload ($uid, $delete_photo = '')
 $display = '';
 
 $action = '';
-$expected = array('edit','save','delete','import','importexec','batchadmin','delbutton_x','reminder_x' );
+$expected = array('edit','save','delete','import','importexec','batchadmin','delbutton_x','delbutton','reminder_x','reminder' );
 foreach($expected as $provided) {
     if (isset($_POST[$provided])) {
         $action = $provided;
@@ -2596,6 +2596,7 @@ switch($action) {
         break;
 
     case 'delbutton_x':
+    case 'delbutton':
         if (SEC_checkToken()) {
             $msg = USER_batchDeleteExec();
             $display .= COM_siteHeader ('menu', $LANG28[11])
@@ -2609,6 +2610,7 @@ switch($action) {
         break;
 
     case 'reminder_x':
+    case 'reminder':
         if (SEC_checkToken()) {
             $msg = USER_sendReminders();
             $display .= COM_siteHeader ('menu', $LANG28[11])


### PR DESCRIPTION
The POST vars delbutton_x and reminder_x aren't used when the icon-type button is used. I left them in for themes that may use images for the buttons, and added `reminder` and `delbutton` actions for the new buttons.