### PR TITLE
Implement classes to manage comment engines

### DIFF
--- a/private/classes/Collection.php
+++ b/private/classes/Collection.php
@@ -1,0 +1,279 @@
+<?php
+/**
+ * Base Class to handle searching and retrieving objects.
+ *
+ * @author      Lee Garner <lee@leegarner.com>
+ * @copyright   Copyright (c) 2022 Lee Garner <lee@leegarner.com>
+ * @package     glfusion
+ * @version     v2.1.0
+ * @since       v2.1.0
+ * @license     http://opensource.org/licenses/gpl-2.0.php
+ *              GNU Public License v2 or later
+ * @filesource
+ */
+namespace glFusion;
+use glFusion\Database\Database;
+use glFusion\Log\Log;
+use glFusion\Cache\Cache;
+use Doctrine\DBAL\Query\QueryBuilder;
+
+
+/**
+ * Class to handle searching and retrieving collections of objects.
+ * @package glfusion
+ */
+class Collection
+{
+    /** Database object.
+     * @var object */
+    protected $_db = NULL;
+
+    /** QueryBuilder object.
+     * @var object */
+    protected $_qb = NULL;
+
+    /** Result statement object.
+     * @var object */
+    protected $_stmt = false;
+
+    /** Tags to add for caching.
+     * @var array */
+    protected $cache_tags = array();
+
+    /** Cache key constructed from SQL query and parameters.
+     * @var string */
+    private $_cache_key = '';
+
+    /** Holder for the number of rows returned from a query.
+     * NULL indicates that the query has not yet been executed.
+     * @var integer */
+    private $_rowcount = NULL;
+
+
+    /**
+     * Instantiate the Database and QueryBuilder objects.
+     */
+    public function __construct()
+    {
+        $this->_db = Database::getInstance();
+        $this->_qb = $this->_db->conn->createQueryBuilder();
+    }
+
+
+    /**
+     * Generic function to add a `where` clause.
+     *
+     * @see     self::setParameter()
+     * @param   string  $sql    SQL to add
+     * @return  object  $this
+     */
+    public function andWhere(string $sql) : self
+    {
+        $this->_qb->andWhere($sql);
+        return $this;
+    }
+
+
+    /**
+     * Generic function to add a parameter value for `andWhere` if needed.
+     *
+     * @see     self::andWhere()
+     * @param   string  $id     Parameter ID name used in andWhere()
+     * @param   mixed   $value  Value to set
+     * @param   integer $type   Type of parameter
+     * @return  object  $this
+     */
+    public function setParameter(string $id, $value, int $type=Database::STRING) : self
+    {
+        $this->_qb->setParameter($id, $value, $type);
+        return $this;
+    }
+
+
+    /**
+     * Set the limit for the result set.
+     *
+     * @param   integer $start  Starting record, or max if $max is empty
+     * @param   integer $max    Max records, optional
+     * @return  object  $this
+     */
+    public function withLimit(int $start, ?int $max=NULL) : self
+    {
+        if (is_null($max)) {
+            $this->_qb->setFirstResult(0)
+                      ->setMaxResults($start);
+        } else {
+            $this->_qb->setFirstResult($start)
+                      ->setMaxResults($max);
+        }
+        return $this;
+    }
+
+
+    /**
+     * Add an orderby clause.
+     *
+     * @param   string  $fld    Field to use for ordering
+     * @param   string  $dir    Direction, ASC by default
+     * @return  object  $this
+     */
+    public function withOrderBy(string $fld, string $dir='ASC') : self
+    {
+        $dir = strtoupper($dir);
+        $dir = $dir == 'ASC' ? 'ASC' : 'DESC';
+        $this->_qb->addOrderBy(Database::getInstance()->conn->quoteIdentifier($fld), $dir);
+        return $this;
+    }
+
+
+    /**
+     * Return the QueryBuilder object for further query customization.
+     *
+     * @return  object      QueryBuilder object
+     */
+    public function getQueryBuilder() : QueryBuilder
+    {
+        return $this->_qb;
+    }
+
+
+    /**
+     * Return the result statement.
+     *
+     * @return  object      Result object
+     */
+    public function getStmt() : object
+    {
+        return $this->_stmt;
+    }
+
+
+    /**
+     * Try to get data from the cache. First constructs the cache key.
+     *
+     * @return  array|null  Array of data, NULL if not found
+     */
+    protected function tryCache() : ?array
+    {
+        $this->_cache_key = md5($this->_qb->getSQL() . self::json_encode($this->_qb->getParameters()));
+        $Cache = Cache::getInstance();
+        if ($Cache->has($this->_cache_key)) {
+            return $Cache->get($this->_cache_key);
+        } else {
+            return NULL;
+        }
+    }
+
+
+    /**
+     * Set a data array into the cache. Key is created by tryCache().
+     *
+     * @param   array   $data   Data to set
+     * @param   array   $tags   Tags to apply
+     */
+    protected function setCache(array $data, array $tags=array()) : void
+    {
+        Cache::getInstance()->set($this->_cache_key, $data, $tags);
+    }
+
+
+    /**
+     * Execute the query and return the Result object.
+     *
+     * @return  object      Doctrine Result object
+     */
+    public function execute() : object
+    {
+        try {
+            $this->_stmt = $this->_qb->execute();
+        } catch (\Throwable $e) {
+            Log::write('system', Log::ERROR, __METHOD__ . ': ' . $e->getMessage());
+            $this->_stmt = false;
+        }
+        // Update _rowcount to know that the query has been executed.
+        if ($this->_stmt) {
+            $this->_rowcount = $this->_stmt->rowCount();
+        } else {
+            $this->_rowcount = 0;
+        }
+        return $this;
+    }
+
+
+    /**
+     * Get the count of rows that would be returned.
+     *
+     * @return  integer     Row count
+     */
+    public function getCount() : int
+    {
+        $retval = 0;
+        if ($this->_rowcount === NULL) {
+            // Not set yet, execute the query.
+            // $this->_rowcount is set in execute().
+            $this->execute();
+        }
+        return $this->_rowcount;
+    }
+
+
+    /**
+     * Get the raw records for the events.
+     *
+     * @return  array       Array of DB rows
+     */
+    public function getRows() : array
+    {
+        $rows = $this->tryCache();
+        if (is_array($rows)) {
+            return $rows;
+        }
+
+        $rows = array();
+        if ($this->_stmt) {
+            while ($row = $this->_stmt->fetchAssociative()) {
+                $rows[] = $row;
+            }
+            // only cache a good DB response
+            $this->setCache($rows, $this->cache_tags);
+        }
+        return $rows;
+    }
+
+
+    /**
+     * Encode an array to a JSON string.
+     * Simple wrapper for json_encode() but makes sure a valid JSON string
+     * is returned.
+     *
+     * @param   array   $arr    Array to encode to JSON
+     * @return  string      JSON string
+     */
+    public static function json_encode(array $arr) : string
+    {
+        try {
+            $retval = json_encode($arr, true);
+        } catch (\Exception $e) {
+            $retval = false;
+        }
+        if (empty($retval)) {
+            $retval = '[]';
+        }
+        return $retval;
+    }
+
+
+    /**
+     * Read the data into objects.
+     * The base class can't implement this since the object type
+     * is not known.
+     *
+     * @return  array       Array of objects
+     */
+    public function readObjects()
+    {
+        return array();
+    }
+
+}
+

--- a/private/classes/Comments/CommentEngine.php
+++ b/private/classes/Comments/CommentEngine.php
@@ -1,0 +1,354 @@
+<?php
+/**
+ * Abstract class to represent a comment engine.
+ * Instantiate by calling CommentEngine::getEngine() which will return
+ * an instance of the configured comment engine.
+ *
+ * @author      Lee Garner <lee@leegarner.com>
+ * @copyright   Copyright (c) 2022 Lee Garner
+ * @package     glfusion
+ * @version     v2.1.0
+ * @since       v2.1.0
+ * @license     http://opensource.org/licenses/gpl-2.0.php
+ *              GNU Public License v2 or later
+ * @filesource
+ */
+namespace glFusion\Comments;
+use glFusion\Database\Database;
+
+
+/**
+ * This class selects the configured comment engine class.
+ * Most of the properties are only used by the Internal engine but are
+ * declared here as they will be populated by calling routines regardless
+ * of which engine is used.
+ *
+ * @package glfusion
+ */
+abstract class CommentEngine
+{
+    /** Comment Code definitions */
+    public const ENABLED = 0;
+    public const DISABLED = -1;
+    public const CLOSED = 1;
+
+    /** Valid comment view modes.
+     * @var array */
+    protected static $valid_modes = array('nested', 'flat', 'nocomment');
+
+    /** Item (story) ID.
+     * @var string */
+    protected $sid = '';
+
+    /** Item title.
+     * @var string */
+    protected $title = '';
+
+    /** Item type, e.g. 'article' or plugin name.
+     * @var string */
+    protected $type = 'article';
+
+    /** Sort order.
+     * @var string */
+    protected $order = 'ASC';
+
+    /** Comment display mode (nested, threaded, flat, etc.)
+     * @var string */
+    protected $mode = '';
+
+    /** Parent comment ID of this one.
+     * @var integer */
+    protected $pid = 0;
+
+    /** Page number being displayed.
+     * @var integer */
+    protected $page = 1;
+
+    /** Flag to use PID as the CID
+     * @var boolean */
+    protected $cid = false;
+
+    /** Flag to indicate the delete option should be shown.
+     * Uses plugin_ismoderator_ function if a value is not set.
+     * @var boolean */
+    protected $delete_option = NULL;
+
+    /** Comment Code (-1=no comments, 0=allowed, 1=closed)
+     * @var integer */
+    protected $ccode = self::ENABLED;
+
+    /** Item (story) author ID, used for highlighting the author.
+     * @var integer */
+    protected $sid_author_id = 0;
+
+    /** Flag indicating preview mode.
+     * @var boolean */
+    protected $preview = false;
+
+
+
+    /**
+     * Set reasonable defaults not set statically above.
+     */
+    public function __construct()
+    {
+        // Call with empty parameter to set configured mode.
+        $this->withMode();
+    }
+
+
+    /**
+     * Set the item (story) ID.
+     *
+     * @param   string  $sid    Item ID
+     * @return  object  $this
+     */
+    public function withSid(string $sid) : self
+    {
+        $this->sid = $sid;
+        return $this;
+    }
+
+
+    /**
+     * Set the item title to be the default comment title.
+     *
+     * @param   string  $title  Item title
+     * @return  object  $this
+     */
+    public function withTitle(string $title) : self
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+
+    /**
+     * Set the item type, e.g. article or plugin name.
+     *
+     * @param   string  $type   Item type
+     * @return  object  $this
+     */
+    public function withType(string $type) : self
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+
+    /**
+     * Set the sort order, either ASC or DESC.
+     *
+     * @param   string  $order  Sort order
+     * @return  object  $this
+     */
+    public function withOrder(string $order) : self
+    {
+        $this->order = strtoupper($order);
+        if ($this->order != 'ASC') $this->order = 'DESC';
+        return $this;
+    }
+
+
+    /**
+     * Set the comment view mode, e.g. 'nested', 'flat', etc.
+     * Uses 'nested' by default.
+     *
+     * @param   string  $mode   Comment mode
+     * @return  object  $this
+     */
+    public function withMode(?string $mode=NULL) : self
+    {
+        global $_CONF;
+
+        if (empty($mode)) {
+            $mode = $_CONF['comment_mode'];
+        }
+        if (!in_array($mode, self::$valid_modes)) {
+            $mode = 'nested';
+        }
+        $this->mode = $mode;
+        return $this;
+    }
+
+
+    /**
+     * Set the parent ID.
+     *
+     * @param   integer $pid    Parent ID
+     * @return  object  $this
+     */
+    public function withPid(int $pid) : self
+    {
+        $this->pid = $pid;
+        return $this;
+    }
+
+    /**
+     * Set the page number to display.
+     *
+     * @param   integer $page   Page number
+     * @return  object  $this
+     */
+    public function withPage(int $page) : self
+    {
+        $this->page = $page;
+        return $this;
+    }
+
+
+    /**
+     * Set the specific comment ID.
+     *
+     * @param   integer $cid    Comment record ID
+     * @return  object  $this
+     */
+    public function withCid(bool $cid=true) : self
+    {
+        $this->cid = $cid;
+        return $this;
+    }
+
+
+    /**
+     * Set the delete option flag.
+     *
+     * @param   boolean $delete_option  True if comment deletion allowed
+     * @return  object  $this
+     */
+    public function withDeleteOption(bool $delete_option=true) : self
+    {
+        $this->delete_option = $delete_option;
+        return $this;
+    }
+
+
+    /**
+     * Set the comment code (enabled, disabled, closed, etc.
+     *
+     * @param   boolean $preview    True if previewing a comment
+     * @return  object  $this
+     */
+    public function withCommentCode(int $ccode) : self
+    {
+        $this->ccode = $ccode;
+        return $this;
+    }
+
+
+    /**
+     * Set the story author ID.
+     *
+     * @param   integer $sid_author_id  Story author's user ID
+     * @return  object  $this
+     */
+    public function withSidAuthorId(int $sid_author_id) : self
+    {
+        $this->sid_author_id = $sid_author_id;
+        return $this;
+    }
+
+
+    /**
+     * Set the preview flag.
+     *
+     * @param   boolean $preview    True if previewing a comment
+     * @return  object  $this
+     */
+    public function withPreview(bool $preview=true) : self
+    {
+        $this->$preview = $preview;
+        return $this;
+    }
+
+
+    /**
+     * Return an instance of the configured comment engine.
+     *
+     * @return  object      Comment Engine instance
+     */
+    public static function getEngine() : object
+    {
+        global $_CONF;
+
+        if (!isset($_CONF['comment_engine'])) {
+            $_CONF['comment_engine'] = 'internal';
+        }
+
+        switch ($_CONF['comment_engine']) {
+        case 'disqus':
+            return new Disqus\Engine;
+        case 'facebook':
+            return new Facebook\Engine;
+        case 'internal':
+        default:
+            return new Internal\Engine;
+        }
+    }
+
+
+    /**
+     * Helper function to see if the user must log in.
+     *
+     * @return  boolean     True if login needed, False if not or logged in
+     */
+    public static function loginRequired() : bool
+    {
+        global $_CONF;
+
+        return (
+            (($_CONF['loginrequired'] == 1) || ($_CONF['commentsloginrequired'] == 1)) &&
+            COM_isAnonUser()
+        );
+    }
+
+
+    /**
+     * Get the URL to the page hosting the comments.
+     *
+     * @return  string      Page URL
+     */
+    public function getPageUrl() : string
+    {
+        global $_CONF;
+
+        if( $this->type == 'article' ) {
+            $url = COM_buildUrl($_CONF['site_url'] . '/article.php?story=' . $this->sid);
+        } else {
+            // Link to plugin defined link or lacking that a generic link
+            // that the plugin should support (hopefully)
+            $parts = PLG_getCommentUrlId($this->type);
+            if (is_array($parts)) {
+                $url = COM_buildUrl("{$parts[0]}?{$parts[1]}={$this->sid}");
+            }
+        }
+        return $url;
+    }
+
+
+    /**
+     * Get a page ID for the item.
+     * Normally just "type_sid".
+     *
+     * @return  string      Page ID
+     */
+    public function getPageId() : string
+    {
+        return $this->type . '_' . $this->sid;
+    }
+
+
+    /**
+     * Get the code needed in the integrated_comments theme field.
+     *
+     * @return  string      API code.
+     */
+    public function getApiCode() : string
+    {
+        return '';
+    }
+
+
+    abstract public function getLinkWithCount(string $type, string $sid, string $url, ?int $cmtCount = NULL);
+}
+

--- a/private/classes/Comments/CommentEngine.php
+++ b/private/classes/Comments/CommentEngine.php
@@ -349,6 +349,31 @@ abstract class CommentEngine
     }
 
 
+    /**
+     * Get the count of comments submitted by user ID.
+     *
+     * @param   integer $uid        User ID
+     * @return  integer     Comment count
+     */
+    public function getCountByUser(int $uid) : int
+    {
+        return 0;
+    }
+
+
+    /**
+     * Get the latest comments from a given user.
+     *
+     * @param   integer $uid        User ID
+     * @param   integer $limit      Optional limit
+     * @return  array       Array of Comment objects
+     */
+    public function getLastX(int $uid, ?int $limit=NULL) : array
+    {
+        return array();
+    }
+
+
     abstract public function getLinkWithCount(string $type, string $sid, string $url, ?int $cmtCount = NULL);
 }
 

--- a/private/classes/Comments/Disqus/Engine.php
+++ b/private/classes/Comments/Disqus/Engine.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Discus engine to retrieve and display comments.
+ *
+ * @author      Lee Garner <lee@leegarner.com>
+ * @copyright   Copyright (c) 2022 Lee Garner
+ * @package     glfusion
+ * @version     v2.1.0
+ * @since       v2.1.0
+ * @license     http://opensource.org/licenses/gpl-2.0.php
+ *              GNU Public License v2 or later
+ * @filesource
+ */
+namespace glFusion\Comments\Disqus;
+
+
+/**
+ * Discus comment engine.
+ * @package glfusion
+ */
+class Engine extends \glFusion\Comments\CommentEngine
+{
+
+    /**
+     * Handle the comment display for Disqus.
+     * Creates the necessary HTML to retrieve Disqus' display.
+     *
+     * @return  string      HTML to render comments
+     */
+    public function displayComments() : string
+    {
+        global $_CONF;
+
+        $retval = '
+            <a name="comments"></a>
+            <div id="disqus_thread"></div>
+            <script>
+                var disqus_config = function () {
+                    this.page.url = \''.$this->getPageUrl().'\';
+                    this.page.identifier = \''.$this->getPageId().'\';
+                    this.page.title = \''.addslashes($this->title).'\';
+                };
+                (function() {
+                    var d = document, s = d.createElement(\'script\');
+                    s.src = \'//'.$_CONF['comment_disqus_shortname'].'.disqus.com/embed.js\';
+                    s.setAttribute(\'data-timestamp\', +new Date());
+                    (d.head || d.body).appendChild(s);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
+            ';
+        return $retval;
+    }
+
+
+    /**
+     * Get a link to the comment display, with the number of comments.
+     *
+     * @param   string  $type       Item type
+     * @param   string  $sid        Item ID
+     * @param   string  $url        URL to comment display
+     * @param   integer $cmtCount   Optional number of comments
+     */ 
+    public function getLinkWithCount(string $type, string $sid, string $url, ?int $cmtCount = NULL) : array
+    {
+        global $LANG01, $_CONF;
+
+        static $done = false;
+        if (!$done) {
+            $outputHandle = \outputHandler::getInstance();
+            $outputHandle->addRawScriptFooter(
+                '<script id="dsq-count-scr" src="//gldev-test-site.disqus.com/count.js" async></script>'
+            );
+            $done = true;
+        }
+        //$url = COM_buildURL($url.'#disqus_thread');
+        if ($type == 'filemgmt') $type = 'filemgmt_fileid';
+
+        $link = '<a href="'.$url.'" data-disqus-identifier='.$type.'_'.$sid.'>';
+        $retval = array(
+            'url'   => $url,
+            'url_extra'=> ' data-disqus-identifier="'.$type.'_'.$sid.'"',
+            //'link'  => $link,
+            'nonlink'   => '<span class="disqus-comment-count" data-disqus-identifier="'.$type.'_'.$sid.'"></span>',
+            'comment_count'=> '<span class="disqus-comment-count" data-disqus-identifier="'.$type.'_'.$sid.'">0 '.$LANG01[83].'</span>',
+            'comment_text'=> $LANG01[83],
+            'link_with_count' => $link.'<span class="disqus-comment-count" data-disqus-identifier="'.$type.'_'.$sid.'">'.$cmtCount.' '.$LANG01[83].'</span></a>',
+        );
+        return $retval;
+    }
+
+}
+

--- a/private/classes/Comments/Disqus/Engine.php
+++ b/private/classes/Comments/Disqus/Engine.php
@@ -60,7 +60,7 @@ class Engine extends \glFusion\Comments\CommentEngine
      * @param   string  $sid        Item ID
      * @param   string  $url        URL to comment display
      * @param   integer $cmtCount   Optional number of comments
-     */ 
+     */
     public function getLinkWithCount(string $type, string $sid, string $url, ?int $cmtCount = NULL) : array
     {
         global $LANG01, $_CONF;

--- a/private/classes/Comments/Facebook/Engine.php
+++ b/private/classes/Comments/Facebook/Engine.php
@@ -46,7 +46,7 @@ class Engine extends \glFusion\Comments\CommentEngine
      * @param   string  $sid        Item ID
      * @param   string  $url        URL to comment display
      * @param   integer $cmtCount   Optional number of comments
-     */ 
+     */
     public function getLinkWithCount(string $type, string $sid, string $url, ?int $cmtCount = NULL) : array
     {
         global $LANG01;

--- a/private/classes/Comments/Facebook/Engine.php
+++ b/private/classes/Comments/Facebook/Engine.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Facebook comment engine functions.
+ *
+ * @author      Lee Garner <lee@leegarner.com>
+ * @copyright   Copyright (c) 2022 Lee Garner
+ * @package     glfusion
+ * @version     v2.1.0
+ * @since       v2.1.0
+ * @license     http://opensource.org/licenses/gpl-2.0.php
+ *              GNU Public License v2 or later
+ * @filesource
+ */
+namespace glFusion\Comments\Facebook;
+
+
+/**
+ * Facebook comment engine.
+ * @package glfusion
+ */
+class Engine extends \glFusion\Comments\CommentEngine
+{
+    /**
+     * Handle the comment display for Facebook.
+     * Creates the necessary HTML to retrieve Facebook's display.
+     *
+     * @return  string      HTML to render comments
+     */
+    public function displayComments()
+    {
+        global $_CONF;
+        static $have_apicode = false;
+
+        $retval = '';
+        $retval .= '<a name="comments"></a>
+            <div class="fb-comments" data-href="' . $this->getPageUrl() .
+            '" data-width="" data-numposts="20"></div>';
+        return $retval;
+    }
+
+
+    /**
+     * Get a link to the comment display, with the number of comments.
+     *
+     * @param   string  $type       Item type
+     * @param   string  $sid        Item ID
+     * @param   string  $url        URL to comment display
+     * @param   integer $cmtCount   Optional number of comments
+     */ 
+    public function getLinkWithCount(string $type, string $sid, string $url, ?int $cmtCount = NULL) : array
+    {
+        global $LANG01;
+
+        $url = COM_buildURL($url);
+        $link = '<a href="'.$url.'">';
+        $retval = array(
+            'url'           => $url,
+            'url_extra'     => '',
+            'link'          => $link,
+            'nonlink'       => '<span class="fb-comments-count" data-href="'.$url.'"></span>',
+            'comment_count' => '<span class="fb-comments-count" data-href="'.$url.'"></span> ' . $LANG01[83],
+            'comment_text'  => $LANG01[83],
+            'link_with_count' => $link.'<span class="fb-comments-count" data-href="'.$url.'"></span>'.' '.$LANG01[83].'</a>',
+        );
+        return $retval;
+    }
+
+
+    /**
+     * Get the code needed in the integrated_comments theme field.
+     * Also sets a meta var for facebook app_id.
+     *
+     * @return  string      API code.
+     */
+    public function getApiCode() : string
+    {
+        global $_CONF;
+        static $done = false;   // Make sure to do it only once
+
+        $retval = '';
+        if (!$done) {
+            $outputHandler = \outputHandler::getInstance();
+            $outputHandler->addRaw('<meta property="fb:app_id" content="{'.$_CONF['comment_fb_appid'].'}" />');
+            $retval .= '<div id="fb-root"></div>
+                <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v15.0&appId=' . $_CONF['comment_fb_appid'] .
+                '&autoLogAppEvents=1" nonce="' . uniqid() . '"></script>';
+            $done = true;
+        }
+        return $retval;
+    }
+
+}
+

--- a/private/classes/Comments/Internal/Comment.php
+++ b/private/classes/Comments/Internal/Comment.php
@@ -890,7 +890,7 @@ class Comment implements \ArrayAccess
         PLG_itemDeleted((int) $cid, 'comment');
 
         Cache::getInstance()->deleteItemsByTags(array('whatsnew','story_'.$sid, 'comments'));
-        echo COM_refresh(self::makeRedirectUrl($this->type, $this->sid));
+        echo COM_refresh(self::makeRedirectUrl($type, $sid));
         return 0;
     }
 

--- a/private/classes/Comments/Internal/Comment.php
+++ b/private/classes/Comments/Internal/Comment.php
@@ -1,0 +1,1225 @@
+<?php
+/**
+ * Class to define a single comment.
+ *
+ * @author      Lee Garner <lee@leegarner.com>
+ * @copyright   Copyright (c) 2022 Lee Garner
+ * @package     glfusion
+ * @version     v2.1.0
+ * @since       v2.1.0
+ * @license     http://opensource.org/licenses/gpl-2.0.php
+ *              GNU Public License v2 or later
+ * @filesource
+ */
+namespace glFusion\Comments\Internal;
+use \glFusion\Database\Database;
+use \glFusion\Cache\Cache;
+use \glFusion\Formatter;
+use \glFusion\Log\Log;
+use \glFusion\Comments\CommentEngine;
+
+USES_lib_user();
+
+
+class Comment implements \ArrayAccess
+{
+/*    private $properties = array(
+        'cid' => 0,
+        'type' => 'article',
+        'sid' => '',
+        'date' => '',
+        'title' => '',
+        'comment' => '',
+        'pid' => 0,
+        'queued' => 0,
+        'postmode' => 'plaintext',
+        'lft' => 0,
+        'rht' => 0,
+        'indent' => 0,
+        'name' => '',
+        'uid' => 0,
+        'ipaddress' => '',
+        'fullname' => '',
+        'photo' => '',
+        'email' => '',
+        'nice_date' => '',
+        'pindent' => 0,
+    );
+ */
+    /** Comment record ID.
+     * @var integer */
+    private $cid = 0;
+
+    /** Item type, e.g. article or plugin name.
+     * @var string */
+    private $type = 'article';
+
+    /** Item ID, e.g. story ID.
+     * @var string */
+    private $sid = '';
+
+    /** Comment submission date.
+     * @var string */
+    private $date = '';
+
+    /** Comment title, defaults to item title.
+     * @var string */
+    private $title = '';
+
+    /** Comment text.
+     * @var string */
+    private $comment = '';
+
+    /** Parent comment ID, for nesting.
+     * @var integer */
+    private $pid = 0;
+
+    /** Flag to indicate the comment is queued (moderated).
+     * @var integer */
+    private $queued = 0;
+
+    /** Post mode, either plaintext or html.
+     * @var string */
+    private $postmode = 'plaintext';
+
+    /** Left comment for MPTT.
+     * @var integer */
+    private $lft = 0;
+
+    /** Right comment for MPTT.
+     * @var integer */
+    private $rht = 0;
+
+    /** Indentation number, for nesting.
+     * @var integer */
+    private $indent = 0;
+
+    /** Submitter's name.
+     * @var string */
+    private $name = '';
+
+    /** Submitter's user ID.
+     * @var integer */
+    private $uid = 0;
+
+    /** Submitter's IP address, sanitized.
+     * @var string */
+    private $ipaddress = '';
+
+    /** Submitter's username. TODO combine with $name above.
+     * @var string */
+    private $username = '';
+
+    /** Submitter's full name from the users table.
+     * @var string */
+    private $fullname = '';
+
+    /** Submitter's photo from the users table.
+     * @var string */
+    private $photo = '';
+
+    /** Submitter's email address from the users table.
+     * @var string */
+    private $email = '';
+
+    /** Nicely-formatted submittion date.
+     * @var string */
+    private $nice_date = '';
+
+    /** Indenting from the parent post.
+     * @var integer */
+    private $pindent = 0;
+
+    /** Direct URL to the comment, used after saving.
+     * @var integer */
+    private $_redirect_url = NULL;
+
+    /** Track errors that occure.
+     * @var array */
+    private $_errors = array();
+
+
+    /**
+     * Get a single comment by its record ID.
+     *
+     * @param   integer $cid        Comment ID
+     * @return  object      Comment object
+     */
+    public static function getByCid(int $cid) : self
+    {
+        global $_TABLES;
+
+        try {
+            $row = Database::getInstance()->conn->executeQuery(
+                "SELECT * FROM {$_TABLES['comments']} WHERE cid = ?",
+                array($cid),
+                array(Database::INTEGER)
+            )->fetchAssociative();
+        } catch (\Throwable $e) {
+            Log::write('system', Log::ERROR, __METHOD__ . ': ' . $e->getMessage());
+            $row = false;
+        }
+        if (is_array($row)) {
+            return self::fromArray($row);
+        } else {
+            return new self;
+        }
+    }
+
+
+    /**
+     * Create a Comment object from an array, such as DB or $_POST.
+     *
+     * @param   array   $A      Array of comment data
+     * @return  object      Comment object
+     */
+    public static function fromArray(array $A) : self
+    {
+        $retval = new self;
+        $retval->setVars($A);
+        return $retval;
+    }
+
+
+    /**
+     * Set the comment properties from an array.
+     *
+     * @param   array   $A      Array of comment data
+     * @return  object  $this
+     */
+    public function setVars(array $A) : self
+    {
+        if (isset($A['cid'])) $this->cid = (int)$A['cid'];
+        if (isset($A['type'])) $this->type = $A['type'];
+        if (isset($A['sid'])) $this->sid = $A['sid'];
+        if (isset($A['date'])) $this->date = $A['date'];
+        if (isset($A['title'])) $this->title = $A['title'];
+        if (isset($A['comment'])) $this->comment = $A['comment'];
+        if (isset($A['pid'])) $this->pid = (int)$A['pid'];
+        if (isset($A['queued'])) $this->queued = (int)$A['queued'];
+        if (isset($A['postmode'])) $this->postmode = $A['postmode'];
+        if (isset($A['lft'])) $this->lft = (int)$A['lft'];
+        if (isset($A['rht'])) $this->rht = (int)$A['rht'];
+        if (isset($A['indent'])) $this->indent = (int)$A['indent'];
+        if (isset($A['name'])) $this->name = $A['name'];
+        if (isset($A['uid'])) $this->uid = (int)$A['uid'];
+        if (isset($A['ipaddress'])) $this->ipaddress = $A['ipaddress'];
+        if (isset($A['username'])) $this->username = $A['username'];
+        if (isset($A['fullname'])) $this->fullname = $A['fullname'];
+        if (isset($A['photo'])) $this->photo = $A['photo'];
+        if (isset($A['email'])) $this->email = $A['email'];
+        if (isset($A['nice_date'])) $this->nice_date = $A['nice_date'];
+        if (isset($A['pindent'])) $this->pindent = (int)$A['pindent'];
+        return $this;
+    }
+
+
+    /**
+     * Get the item (story) ID for the comment.
+     *
+     * @return  string      Item ID
+     */
+    public function getSid() : string
+    {
+        return $this->sid;
+    }
+
+
+    /**
+     * Get the item type or plugin name.
+     *
+     * @return  string      Item type
+     */
+    public function getType() : string
+    {
+        return $this->type;
+    }
+
+
+    /**
+     * Get the comment record ID.
+     *
+     * @return  integer     Record ID
+     */
+    public function getCid() : int
+    {
+        return $this->cid;
+    }
+
+
+    /**
+     * Get the comment author's ID.
+     *
+     * @return  integer     Author UID
+     */
+    public function getUid() : int
+    {
+        return $this->uid;
+    }
+
+
+    /**
+     * Get the comment text.
+     *
+     * @return  string      Comment text
+     */
+    public function getComment() : string
+    {
+        return $this->comment;
+    }
+
+
+    /**
+     * Get the item title.
+     *
+     * @return  string      Item title
+     */
+    public function getTitle() : string
+    {
+        return $this->title;
+    }
+
+
+    /**
+     * Get the parent comment ID.
+     *
+     * @reurn   integer     Parent comment ID
+     */
+    public function getPid() : int
+    {
+        return $this->pid;
+    }
+
+
+    /**
+     * Get the postmode used for the comment.
+     *
+     * @return  string      'html' or 'text'
+     */
+    public function getPostmode() : string
+    {
+        return $this->postmode;
+    }
+
+
+    /**
+     * Get the date of the comment.
+     *
+     * @return  string      Date of the comment
+     */
+    public function getDate() : string
+    {
+        return $this->date;
+    }
+
+
+    /**
+     * Get the URL to redirect after saving.
+     *
+     * @return  string      URL to item view or other page.
+     */
+    public function getRedirectUrl() : string
+    {
+        if ($this->_redirect_url === NULL) {
+            $this->_redirect_url = self::makeRedirectUrl($this->type, $this->sid);
+        }
+        return $this->_redirect_url;
+    }
+
+
+    /**
+     * Save a comment.
+     *
+     * @param   array   $A      Optional array of data from $_POST
+     * @return  boolean     True for success, Fale on error
+     */
+    public function save(?array $A=NULL) : bool
+    {
+        global $_CONF, $_TABLES, $_USER, $LANG03, $LANG_ADM_ACTIONS;
+
+        $commentUid = $this->uid;   // get the original commenter ID
+
+        if (is_array($A)) {
+            $this->setVars($A);
+        }
+
+        if (empty($this->title)) {
+            $info = PLG_getItemInfo($this->type, $this->sid, 'id,title');
+            $this->title = (isset($info['title']) ? $info['title'] : 'Comment');
+        }
+
+        if (!$this->checkValidData()) {
+            return false;
+        }
+
+        if (isset($A['comment_text'])) {
+            $this->comment = $A['comment_text'];
+        }
+
+        $db = Database::getInstance();
+
+        // Get a valid uid
+        if (empty ($_USER['uid'])) {
+            $uid = 1;
+        } else {
+            $uid = $_USER['uid'];
+        }
+
+        // Check that anonymous comments are allowed
+        if (CommentEngine::loginRequired()) {
+            Log::write('system',Log::WARNING,'CMT_saveComment: IP address '.$_SERVER['REAL_ADDR'].' '
+                . 'attempted to save a comment with anonymous comments disabled for site.');
+            COM_setMsg('Login is required to save a comment.');
+            return false;
+        }
+
+        // Check for people breaking the speed limit
+        COM_clearSpeedlimit ($_CONF['commentspeedlimit'], 'comment');
+        $last = COM_checkSpeedlimit ('comment');
+        if ($last > 0) {
+            Log::write('system',Log::WARNING,'CMT_saveComment: '.$uid.' from IP address '.$_SERVER['REAL_ADDR'].' '
+                . 'attempted to submit a comment before the speed limit expired.');
+            COM_setMsg('Attempting to save comments too fase.');
+            return false;
+        }
+
+        if ( COM_isAnonUser() ) {
+            if (isset($_POST['username']) ) {
+                $this->name = @htmlspecialchars(strip_tags(trim(COM_checkWords(USER_sanitizeName($_POST['username'])))),ENT_QUOTES,COM_getEncodingt(),true);
+                $this->name = USER_uniqueUsername($this->name);
+            } else {
+                $this->name = '';
+            }
+            $this->email = '';  // just to be sure
+        } else {
+            $this->name = $_USER['username'];
+            $this->email = $_USER['email'];
+        }
+
+        // Error Checking
+        if (empty ($this->sid) || empty ($this->comment) || empty ($this->type) ) {
+            Log::write('system',Log::WARNING,'CMT_saveComment: '.$uid.' from '.$_SERVER['REAL_ADDR'].' tried to submit a comment with one or more missing values.');
+            if ( SESS_isSet('glfusion.commentpresave.error') ) {
+                $msg = SESS_getVar('glfusion.commentpresave.error') . '<br/>' . $LANG03[12];
+            } else {
+                $msg = $LANG03[12];
+            }
+            SESS_setVar('glfusion.commentpresave.error',$msg);
+
+            return $ret = 1;
+        }
+
+        if (!is_numeric($this->pid) || ($this->pid < 0)) {
+            $this->pid = 0;
+        }
+
+        // Call Spam based plugins
+        $spamcheck = '<h1>' . $this->title . '</h1><p>' . $this->comment . '</p>';
+        $spamData = array(
+            'username' => $this->username,
+            'email'    => $this->email,
+            'ip'       => $_SERVER['REAL_ADDR'],
+            'type'     => 'comment'
+        );
+        $result = PLG_checkforSpam($spamcheck, $_CONF['spamx'], $spamData);
+
+        // update speed limit nonetheless
+        COM_updateSpeedlimit ('comment');
+
+        // Now check the result and display message if spam action was taken
+        if ($result > 0) {
+            // then tell them to get lost ...
+            COM_displayMessageAndAbort ($result, 'spamx', 403, 'Forbidden');
+        }
+
+        // Let plugins have a chance to decide what to do before saving the comment, return errors.
+        if ($someError = PLG_commentPreSave($uid, $this->title, $this->comment, $this->sid, $this->pid, $this->type, $this->postmode)) {
+            return $someError;
+        }
+
+        // determine if we are queuing
+        if (isset($_CONF['commentssubmission'] ) && $_CONF['commentssubmission'] > 0) {
+            switch ( $_CONF['commentssubmission'] ) {
+            case 1 : // anonymous only
+                if ( COM_isAnonUser() ) {
+                    $this->queued = 1;
+                }
+                break;
+            case 2 : // all users
+            default :
+                $this->queued = 1;
+                break;
+            }
+            if ( SEC_hasRights('comment.submit') ) {
+                $this->queued = 0;
+            }
+        }
+
+        $moderatorEdit = false;     // make sure the variable is defined
+
+        if ($this->cid > 0) {
+            $_edit = true;      // updating an existing comment
+            // flag indicating the edit is done from the moderation.php page
+            $moderatorEdit = isset($A['modedit']) && self::isModerator();
+            $silentEdit = isset($_POST['silent_edit']);
+            if (!self::isModerator() && $_USER['uid'] != $commentUid) {
+                // non-moderator trying to edit someone else's comment
+                return false;
+            }
+
+            /*$values = array(
+                'comment'   => $this->comment,
+                'title'     => $this->title,
+                'name'      => $this->username,
+                'postmode'  => $this->postmode,
+            );
+            $types = array(
+                Database::STRING,
+                Database::STRING,
+                Database::STRING,
+                Database::STRING,
+            );*/
+            try {
+                $db->conn->update(
+                    $_TABLES['comments'],
+                    array(
+                        'comment'   => $this->comment,
+                        'title'     => $this->title,
+                        'name'      => $this->username,
+                        'postmode'  => $this->postmode,
+                        'queued'    => $this->queued,
+                    ),
+                    array(
+                        'cid' => $this->cid,
+                        'sid' => $this->sid
+                    ),
+                    array(
+                        Database::STRING,
+                        Database::STRING,
+                        Database::STRING,
+                        Database::STRING,
+                        Database::INTEGER,
+                        Database::INTEGER,
+                        Database::STRING
+                    )
+                );
+            } catch (\Throwable $e) {
+                Log::write('system', Log::ERROR, __METHOD__ . ': ' . $e->getMessage());
+                $this->_errors[] = 'There was an error saving to the database.';
+                return false;
+            }
+            if ($moderatorEdit) {
+                \glFusion\Admin\AdminAction::write(
+                    'comment',
+                    'mod_edit',
+                    sprintf($LANG_ADM_ACTIONS['comment_edit'], $this->cid, $this->title)
+                );
+            } else {
+                if (!$silentEdit) {
+                    PLG_itemSaved($this->cid, 'comment');
+                    $db->conn->executestatement(
+                        "REPLACE INTO `{$_TABLES['commentedits']}`
+                            (cid,uid,time) VALUES (?,?,?)",
+                        array($this->cid, $this->uid, $_CONF['_now']->toMySQL(true)),
+                        array(Database::INTEGER, Database::INTEGER, Database::STRING)
+                    );
+                }
+                PLG_commentEditSave($this->type, $this->cid, $this->sid);
+            }
+        } else {
+            $_edit = false;     // creating a new comment
+            $this->ipaddress = $_SERVER['REMOTE_ADDR'];
+            $this->cid = 0;
+
+            if ($this->pid > 0) { // reply to an existing comment
+                $row = $db->conn->fetchAssoc(
+                    "SELECT rht, indent FROM `{$_TABLES['comments']}` WHERE cid = ? AND sid = ?",
+                    array($this->pid, $this->sid),
+                    array(Database::INTEGER, Database::STRING)
+                );
+                if ($row === false) {
+                    Log::write('system',Log::WARNING,'CMT_saveComment: '.$uid.' from '.$_SERVER['REAL_ADDR'].' tried '
+                        . 'to reply to a non-existent comment or the pid/sid did not match');
+                    COM_setMsg('Invalid parent comment for reply');
+                    return false;
+                }
+                $rht    = $row['rht'];
+                $indent = $row['indent'];
+
+                $db->conn->executeStatement("LOCK TABLES `{$_TABLES['comments']}` WRITE");
+                $db->conn->beginTransaction();
+                try {
+                    $db->conn->executeUpdate(
+                        "UPDATE `{$_TABLES['comments']}` SET lft = lft + 2
+                        WHERE sid = ? AND type = ? AND lft >= ?",
+                        array($this->sid, $this->type, $rht),
+                        array(Database::STRING, Database::STRING, Database::INTEGER)
+                    );
+                    $db->conn->executeUpdate(
+                        "UPDATE `{$_TABLES['comments']}` SET rht = rht + 2
+                        WHERE sid = ? AND type = ? AND rht >= ?",
+                        array($this->sid, $this->type, $rht),
+                        array(Database::STRING, Database::STRING, Database::INTEGER)
+                    );
+                } catch (\Doctrine\DBAL\Exception\RetryableException $e) {
+                    $db->conn->commit();
+                    $db->conn->executeStatement("UNLOCK TABLES `{$_TABLES['comments']}` WRITE");
+                    usleep(250000);
+                } catch (\Exception $e) {
+                    Log::write('system', Log::ERROR, __METHOD__ . ': ' . $e->getMessage());
+                    $db->conn->rollBack();
+                    $db->conn->executeStatement("UNLOCK TABLES");
+                    throw($e);
+                }
+            } else {  // first - parent level comment
+                $db->conn->executeStatement("LOCK TABLES `{$_TABLES['comments']}` WRITE");
+                $db->conn->beginTransaction();
+                try {
+                    $rht = $db->conn->fetchColumn(
+                        "SELECT MAX(rht) FROM `{$_TABLES['comments']}` WHERE sid=?",
+                        array($this->sid),
+                        0
+                    );
+                } catch(Throwable $e) {
+                    Log::write('system', Log::ERROR, __METHOD__ . ': ' . $e->getMessage());
+                    $rht = false;
+                }
+                if (empty($rht)) {
+                    $rht = 0;
+                }
+                $indent = 0;
+            }
+            $values = array(
+                'sid' => $this->sid,
+                'uid' => $this->uid,
+                'name' => $this->username,
+                'comment' => $this->comment,
+                'date' => $_CONF['_now']->toMySQL(true),
+                'title' => $this->title,
+                'pid' => $this->pid,
+                'queued' => $this->queued,
+                'postmode' => $this->postmode,
+                'lft' => $rht,
+                'rht' => $rht+1,
+                'indent' => $indent+1,
+                'type' => $this->type,
+                'ipaddress' => $this->ipaddress,
+            );
+            $types = array(
+                Database::STRING,
+                Database::INTEGER,
+                Database::STRING,
+                Database::STRING,
+                Database::STRING, // date
+                Database::STRING, // title
+                Database::INTEGER, // pid
+                Database::INTEGER, // queued
+                Database::STRING, // postmode
+                Database::INTEGER, //rht
+                Database::INTEGER, // rht+1
+                Database::INTEGER, // indent
+                Database::STRING // IP
+            );
+
+            try {
+                $db->conn->insert($_TABLES['comments'], $values, $types);
+                $this->cid = $db->conn->lastInsertId();
+                $db->conn->commit();
+                $db->conn->executeStatement("UNLOCK TABLES");
+            } catch (\Doctrine\DBAL\Exception\RetryableException $e) {
+                $db->conn->commit();
+                $db->conn->executeStatement("UNLOCK TABLES");
+                usleep(250000);
+            } catch (\Exception $e) {
+                $db->conn->rollBack();
+                $db->conn->executeStatement("UNLOCK TABLES");
+                throw($e);
+            }
+
+            if (!$this->queued) {
+                $c = Cache::getInstance();
+                $c->deleteItemsByTags('whatsnew', 'comments');
+                if ($this->type == 'article') {
+                    $c->deleteItemsByTag('story_'.$this->sid);
+                }
+                PLG_itemSaved($this->cid, 'comment');
+            } else {
+                $c = Cache::getInstance()->deleteItemsByTag('menu');
+                SESS_setVar('glfusion.commentpostsave',$LANG03[52]);
+            }
+
+            // check to see if user has subscribed....
+            if ( !COM_isAnonUser() ) {
+                if (isset($A['subscribe']) && $A['subscribe'] == 1) {
+                    $itemInfo = PLG_getItemInfo($this->type, $this->sid, 'url,title');
+                    if (isset($itemInfo['title']) ) {
+                        $id_desc = $itemInfo['title'];
+                    } else {
+                        $id_desc = 'not defined';
+                    }
+                    $rc = PLG_subscribe('comment', $this->type, $this->sid, $uid, $this->type, $id_desc);
+                } else {
+                    PLG_unsubscribe('comment', $this->type, $this->sid);
+                }
+            }
+            if (
+                isset ($_CONF['notification']) &&
+                in_array ('comment', $_CONF['notification'])
+            ) {
+                $this->sendNotification();
+            }
+
+            if (!$this->queued) {
+                // handles sending out subscription emails
+                PLG_sendSubscriptionNotification('comment',$this->type,$this->sid,$this->cid,$uid);
+            }
+        }
+
+        Cache::getInstance()->deleteItemsByTags(array('comments'));
+        if ($moderatorEdit) {
+            $this->_redirect_url = $_CONF['site_admin_url'].'/moderation.php';
+        } else {
+            $this->_redirect_url = self::makeRedirectUrl($this->type, $this->sid);
+        }
+        return true;
+    }
+
+
+    /**
+     * Send an email notification to mod / admin for a new comment submission.
+     */
+    public function sendNotification() : void
+    {
+        global $_CONF, $_TABLES, $LANG03, $LANG08, $LANG09;
+
+        $filter = sanitizer::getInstance();
+        $db = Database::getInstance();
+
+        $author = $filter->sanitizeUsername($this->username . ' ('.$this->ipaddress.')');
+        $type   = $this->type;
+        $html2txt  = new Html2Text\Html2Text(strip_tags($this->title), false);
+        $title = trim($html2txt->get_text());
+
+        // build out the view
+
+        $format = new Formatter();
+        $format->setNamespace('glfusion');
+        $format->setAction('comment');
+        $format->setAllowedHTML($_CONF['htmlfilter_comment']);
+        $format->setParseAutoTags(true);
+        $format->setProcessBBCode(false);
+        $format->setCensor(true);
+        $format->setProcessSmilies(false);
+        $format->setType($this->postmode);
+        $comment = $format->parse($this->comment);
+
+        if ($_CONF['emailstorieslength'] > 1) {
+            $comment = COM_truncateHTML ( $comment, $_CONF['emailstorieslength']);
+        }
+        // we have 2 different types of email - one for queued and one for alerting
+        if ( !$this->queued ) {
+            $mailbody = "$LANG03[16]: " . $title ."<br>"
+                  . "$LANG03[5]: "  . $author."<br>";
+            if (($this->type != 'article') && ($this->type != 'poll')) {
+                $mailbody .= "$LANG09[5]: {$this->type}<br>";
+            }
+            $mailbody .= '<br>'. $comment . '<br>';
+            $mailbody .= $LANG08[33] . ' ' . $_CONF['site_url']
+                  . '/comment.php?mode=view&cid=' . $this->cid . "<br><br>";
+            $mailbody .= "------------------------------<br>";
+            $mailbody .= "$LANG08[34]";
+            $mailbody .= "<br>------------------------------<br>";
+
+            $mailsubject = $_CONF['site_name'] . ' ' . $LANG03[9];
+
+        } else {
+            $mailbody  = $LANG03[53].'<br><br>';
+            $mailbody .= $LANG03[16].': '. $title .'<br>';
+            $mailbody .= $LANG03[5].': ' . $author.'<br><br>';
+            $mailbody .= $comment . '<br><br>';
+            $mailbody .= sprintf($LANG03[54].'<br>',$_CONF['site_admin_url'].'/moderation.php');
+
+            $mailsubject = $LANG03[55];
+        }
+
+        // now we have the HTML mail message built
+        // build text version
+        $html2txt  = new \Html2Text\Html2Text($mailbody,false);
+        $mailbody_text = trim($html2txt->get_text());
+
+        $to = array();
+        $msgData = array();
+        $toCount = 0;
+
+        if ( $commentData['queued'] == 0 ) {
+            $to[] = array('email' => $_CONF['site_mail'], 'name' => '');
+            $toCount++;
+        } else {
+            $commentadmin_grp_id = $db->conn->fetchColumn(
+                "SELECT grp_id FROM `{$_TABLES['groups']}` WHERE grp_name='Comment Admin'",
+                array(),
+                0
+            );
+            if ( $commentadmin_grp_id === null ) {
+                return;
+            }
+            $groups = SEC_getGroupList($commentadmin_grp_id);
+
+	        $sql = "SELECT DISTINCT {$_TABLES['users']}.uid,username,fullname,email "
+	              ."FROM `{$_TABLES['group_assignments']}`,`{$_TABLES['users']}` "
+	              ."WHERE {$_TABLES['users']}.uid > 1 "
+    	          ."AND {$_TABLES['users']}.uid = {$_TABLES['group_assignments']}.ug_uid "
+	              ."AND ({$_TABLES['group_assignments']}.ug_main_grp_id IN (?))";
+
+            $stmt = $db->conn->executeQuery($sql,array($groups),array(Database::PARAM_INT_ARRAY));
+            $resultSet = $stmt->fetchAll(Database::ASSOCIATIVE);
+
+            foreach($resultSet AS $row) {
+                if ( $row['email'] != '' ) {
+                    $toCount++;
+                    $to[] = array('email' => $row['email'], 'name' => $row['username']);
+                }
+            }
+        }
+        if ( $toCount > 0 ) {
+            $msgData['htmlmessage'] = $mailbody;
+            $msgData['textmessage'] = $mailbody_text;
+            $msgData['subject']     = $mailsubject;
+            $msgData['from']['email'] = $_CONF['noreply_mail'];
+            $msgData['from']['name'] = $_CONF['site_name'];
+            $msgData['to'] = $to;
+            COM_emailNotification( $msgData );
+        }
+    }
+
+
+    /**
+     * Deletes a given comment.
+     *
+     * The function expects the calling function to check to make sure the
+     * requesting user has the correct permissions and that the comment exits
+     * for the specified $type and $sid.
+     *
+     * @author  Vincent Furia, vinny01 AT users DOT sourceforge DOT net
+     * @param   string      $type   article, poll, or plugin identifier
+     * @param   string      $sid    id of object comment belongs to
+     * @param   int         $cid    Comment ID
+     * @return  string      0 indicates success, >0 identifies problem
+     */
+    public static function delete(int $cid, string $sid, string $type) : string
+    {
+        global $_CONF, $_TABLES, $_USER;
+
+        $ret = 0;  // Assume good status unless reported otherwise
+
+        // Sanity check, note we return immediately here and no DB operations
+        // are performed
+        if (!is_numeric ($cid) || ($cid < 0) || empty ($sid) || empty ($type)) {
+            Log::write('system',Log::WARNING,'CMT_deleteComment: '.$_USER['uid'].' from '.$_SERVER['REAL_ADDR'].' tried '
+                   . 'to delete a comment with one or more missing/bad values.');
+            return 1;
+        }
+
+        $db = Database::getInstance();
+
+        // Delete the comment from the DB and update the other comments to
+        // maintain the tree structure
+        // A lock is needed here to prevent other additions and/or deletions
+        // from happening at the same time. A transaction would work better,
+        // but aren't supported with MyISAM tables.
+
+        $db->conn->executeStatement("LOCK TABLES `{$_TABLES['comments']}` WRITE");
+        $db->conn->beginTransaction();
+        try {
+            $cmtData = $db->conn->fetchAssoc(
+                "SELECT pid, lft, rht FROM `{$_TABLES['comments']}`
+                WHERE cid = ? AND sid = ? AND type = ?",
+                array($cid,$sid,$type),
+                array(Database::INTEGER, Database::STRING, Database::STRING)
+            );
+            if ($cmtData === false) {
+                Log::write('system',Log::WARNING,'CMT_deleteComment: '.$_USER['uid'].' from '.$_SERVER['REAL_ADDR'].' tried '
+                       . 'to delete a comment that doesn\'t exist as described.');
+                return $ret = 2;
+            }
+            $pid = $cmtData['pid'];
+            $rht = $cmtData['rht'];
+            $lft = $cmtData['lft'];
+
+            $db->conn->update(
+                $_TABLES['comments'],
+                array('pid' => $pid),
+                array('pid' => $cid),
+                array(Database::INTEGER, Database::INTEGER)
+            );
+            $db->conn->delete(
+                $_TABLES['comments'],
+                array('cid' => $cid),
+                array(Database::INTEGER)
+            );
+            $db->conn->executeStatement(
+                "UPDATE {$_TABLES['comments']} SET indent = indent - 1
+                WHERE sid = ? AND type = ? AND lft BETWEEN ? AND ?",
+                array($sid, $type, $lft, $rht),
+                array(Database::STRING, Database::STRING, Database::INTEGER, Database::INTEGER)
+            );
+            $db->conn->executeStatement(
+                "UPDATE `{$_TABLES['comments']}` SET lft = lft - 2
+                WHERE sid = ? AND type = ?  AND lft >= ?",
+                array($sid, $type, $rht),
+                array(Database::STRING, Database::STRING, Database::INTEGER)
+            );
+            $db->conn->executeUpdate(
+                    "UPDATE `{$_TABLES['comments']}` SET rht = rht - 2 WHERE sid = ? AND type = ?  AND rht >= ?",
+                    array($sid,$type,$rht),
+                    array(Database::STRING,Database::STRING,Database::INTEGER)
+            );
+            $db->conn->commit();
+            $db->conn->executeStatement("UNLOCK TABLES");
+        } catch (\Doctrine\DBAL\Exception\RetryableException $e) {
+            $db->conn->commit();
+            $db->conn->executeStatement("UNLOCK TABLES");
+            usleep(250000);
+        } catch(Throwable $e) {
+            Log::write('system', Log::ERROR, __METHOD__ . ': ' . $e->getMessage());
+            $db->conn->rollBack();
+            $db->conn->executeStatement("UNLOCK TABLES");
+            throw($e);
+        }
+
+        PLG_itemDeleted((int) $cid, 'comment');
+
+        Cache::getInstance()->deleteItemsByTags(array('whatsnew','story_'.$sid, 'comments'));
+        echo COM_refresh(self::makeRedirectUrl($this->type, $this->sid));
+        return 0;
+    }
+
+
+    /**
+     * Filters comment text and appends necessary tags (sig and/or edit).
+     *
+     * @copyright Jared Wenerd 2008
+     * @author Jared Wenerd <wenerd87 AT gmail DOT com>
+     * @param string  $comment   comment text
+     * @param bool    $edit     if true append edit tag
+     * @param int     $cid      commentid if editing comment (for proper sig)
+     * @return string of comment text
+     * @@ WE are retiring this function
+     */
+    public function prepareText($edit = false) : string
+    {
+        global $_CONF;
+
+        $filter = sanitizer::getInstance();
+        $filter->setPostmode($this->postmode);
+        $filter->setCensorData(true);
+        $filter->setNamespace('glfusion','comment');
+        $AllowedElements = $filter->makeAllowedElements($_CONF['htmlfilter_comment']);
+        $filter->setAllowedElements($AllowedElements);
+
+        if ($this->postmode != 'text') {
+            $comment = $filter->filterHTML($this->comment);
+        }
+        return $comment;
+    }
+
+
+    /**
+     * Creates the preview above the edit form.
+     *
+     * @param   array   $A  Data posted
+     * @return  string      HTML for preview
+     */
+    public function preview(?array $A=NULL) : string
+    {
+        global $_CONF, $_TABLES,$_USER,$LANG03;
+
+        $retval = '';
+        $mode = 'preview_edit';
+        $start = new \Template( $_CONF['path_layout'] . 'comment' );
+        $start->set_file( array( 'comment' => 'startcomment.thtml' ));
+        $start->set_var( 'hide_if_preview', 'style="display:none"' );
+
+        $db = Database::getInstance();
+
+        // Clean up all the vars
+        if (is_array($A)) {
+            foreach ($A as $key => $value) {
+                switch ($key) {
+                case 'pid':
+                case 'sid':
+                    $A[$key] = (int) COM_applyFilter ($A[$key], true);
+                    break;
+                case 'title':
+                case 'comment':
+                    // noop = these have already been filtered above
+                    // now we want the raw data
+                    break;
+                case 'username':
+                    $A[$key] = @htmlspecialchars(strip_tags(trim(COM_checkWords(USER_sanitizeName($A[$key])))),ENT_QUOTES,COM_getEncodingt());
+                    break;
+                default:
+                    $A[$key] = COM_applyFilter($A[$key]);
+                }
+            }
+            $this->setVars($A);
+        }
+
+        //correct time and username for edit preview
+        if ($mode == 'preview' || $mode == 'preview_new' || $mode == 'preview_edit') {
+            $A['nice_date'] = $db->conn->fetchColumn(
+                "SELECT UNIX_TIMESTAMP(date) FROM `{$_TABLES['comments']}` WHERE cid = ?",
+                array($this->cid),
+                0,
+                array(Database::INTEGER)
+            );
+        }
+        if (empty ($A['username'])) {
+            $A['username'] = $db->conn->fetchColumn(
+                "SELECT username FROM `{$_TABLES['users']}` WHERE uid=?",
+                array($this->uid),
+                0,
+                array(Database::INTEGER)
+            );
+        }
+
+        $author_id = PLG_getItemInfo($this->type, $this->sid, 'author');
+
+        // Leverage the CommentCollection to create the preview
+        // from this comment.
+        $Coll = new CommentCollection;
+        $Coll->pushComment($this);
+        $thecomments = CommentEngine::getEngine()->renderComments($Coll);
+
+        $start->set_var( 'comments', $thecomments );
+        $retval .= '<a name="comment_entry"></a>';
+        $retval .= COM_startBlock ($LANG03[14])
+            . $start->finish( $start->parse( 'output', 'comment' ))
+            . COM_endBlock ();
+
+        return $retval;
+    }
+
+
+    /**
+     * Returns number of comments for a specific item.
+     *
+     * @param   string  $type       Type of object comment is posted to
+     * @param   string  $sid        ID of object comment belongs to
+     * @param   integer $queued     Queued (0) or published (1)
+     * @return  integer     Number of comments
+     */
+    public static function getCount(string $type, string $sid, int $queued = 0) : int
+    {
+        global $_TABLES;
+
+        $db = Database::getInstance();
+
+        if ( $type == '' || $sid == '' ) return 0;
+
+        return Database::getInstance()->getCount(
+            $_TABLES['comments'],
+            array('sid', 'type', 'queued'),
+            array($sid, $type, $queued),
+            array(Database::STRING, Database::STRING, Database::INTEGER)
+        );
+    }
+
+
+    /**
+     * Check if the current user is a comment moderator and cache the result.
+     *
+     * @return  boolean     True if a moderator
+     */
+    public static function isModerator() : bool
+    {
+        static $retval = NULL;
+        if ($retval === NULL) {
+            $retval = SEC_hasRights('comment.moderate');
+        }
+        return $retval;
+    }
+
+
+    /**
+     * Get the redirect url to return to an item view.
+     *
+     * @param   string  $type   Item type, e.g. 'article' or plugin name
+     * @param   string  $sid    Optional item ID
+     * @return  object  $this
+     */
+    public static function makeRedirectUrl(string $type, ?string $sid=NULL) : string
+    {
+        global $_CONF;
+
+        $urlArray = PLG_getCommentUrlId($type);
+        if (is_array($urlArray)) {
+            $url = $urlArray[0];
+            if (!is_null($sid)) {
+                $url .= '?' . $urlArray[1] . '=' . $sid;
+            }
+        } else {
+            $url = $_CONF['site_url'] . '/index.php';
+        }
+        return $url;
+    }
+
+
+    /**
+     * Check that the minimum required information is provided before saving.
+     *
+     * @return  boolean     True if fields are valid
+     */
+    public function checkValidData() : bool
+    {
+        global $_PLUGINS;
+
+        if ($this->type != 'article' && !in_array($this->type, $_PLUGINS)) {
+            Log::write('system', Log::WARNING, __METHOD__ . ': invalid item type for comment');
+            $this->_errors[] = 'Invalid item type for comment.';
+            return false;
+        }
+        if (empty($this->sid) /*|| empty($this->title)*/ || empty($this->comment)) {
+            Log::write('system', Log::WARNING, __METHOD__ . ': invalid data for comment values');
+            $this->_errors[] = 'Some fields are missing or invalid';
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Get a ready-to-display error message from the accumulated error strings.
+     *
+     * @return  string      Unnumbered HTML list of errors
+     */
+    public function printErrors() : string
+    {
+        $retval = '';
+        if (!empty($this->_errors)) {
+            $retval = '<ul><li>' . implode('</li><li>', $this->_errors) . '</li></ul>';
+        }
+        return $retval;
+    }
+
+
+/*    public function toArray() : array
+    {
+        return array(
+            'cid'])) $this->cid = (int)$A['cid'];
+        'type'])) $this->type = $A['type'];
+        'sid'])) $this->sid = $A['sid'];
+        'date'])) $this->date = $A['date'];
+        'title'])) $this->title = $A['title'];
+        'comment'])) $this->comment = $A['comment'];
+        'pid'])) $this->pid = (int)$A['pid'];
+        'queued'])) $this->queued = (int)$A['queued'];
+        'postmode'])) $this->postmode = $A['postmode'];
+        'lft'])) $this->lft = (int)$A['lft'];
+        'rht'])) $this->rht = (int)$A['rht'];
+        'indent'])) $this->indent = (int)$A['indent'];
+        'name'])) $this->name = $A['name'];
+        'uid'])) $this->uid = (int)$A['uid'];
+        'ipaddress'])) $this->ipaddress = $A['ipaddress'];
+        'username'])) $this->username = $A['username'];
+        'fullname'])) $this->fullname = $A['fullname'];
+        'photo'])) $this->photo = $A['photo'];
+        'email'])) $this->email = $A['email'];
+        'nice_date'])) $this->nice_date = $A['nice_date'];
+        'pindent'])) $this->pindent = (int)$A['pindent'];
+        return $this;
+}*/
+
+    /**
+     * Set a property value.
+     *
+     * @param   string  $key    Key name
+     * @param   mixed   $value  Value to set
+     */
+    public function offsetSet($key, $value)
+    {
+        $this->$key = $value;
+    }
+
+
+    /**
+     * Check if a key exists.
+     *
+     * @param   mixed   $key    Key name
+     * @return  boolean     True if the key exists.
+     */
+    public function offsetExists($key)
+    {
+        return isset($this->$key);
+    }
+
+
+    /**
+     * Remove a property.
+     *
+     * @param   mixed   $key    Key name
+     */
+    public function offsetUnset($key)
+    {
+        unset($this->$key);
+    }
+
+
+    /**
+     * Get a value from the properties.
+     *
+     * @param   mixed   $key    Key name
+     * @return  mixed       Value of property, NULL if not set
+     */
+    public function offsetGet($key)
+    {
+        return isset($this->$key) ? $this->$key : NULL;
+    }
+
+
+    /**
+     * Get the comment properties as an array.
+     *
+     * @return  array       Properties array
+     */
+    /*public function toArray()
+    {
+        return $this->properties;
+    }*/
+
+
+    public function approve() : bool
+    {
+        global $_TABLES;
+
+        $db = Database::getInstance();
+        try {
+            $stmt = $db->conn->update(
+                $_TABLES['comments'],
+                array('queued' => 0),
+                array('cid' => $this->cid),
+                array(Database::INTEGER, Database::INTEGER)
+            );
+        } catch (\Throwable $e) {
+            if ($db->getIgnore()) {
+                $db->_errorlog("SQL Error: " . $e->getMessage());
+            } else {
+                $db->dbError($e->getMessage(),$sql);
+                return false;
+            }
+        }
+
+        // let plugins know they should update their counts if necessary
+        PLG_commentApproved($this->cid, $this->type, $this->sid);
+        $c = Cache::getInstance();
+        $c->deleteItemsByTags(array('whatsnew','menu', 'comments'));
+        if ($this->type == 'article') {
+            $c->deleteItemsByTag('story_'.$this->sid);
+        }
+        // let others know we saved a comment to the prod table
+        PLG_itemSaved($this->cid, 'comment');
+        return true;
+    }
+
+}
+

--- a/private/classes/Comments/Internal/CommentBar.php
+++ b/private/classes/Comments/Internal/CommentBar.php
@@ -1,0 +1,303 @@
+<?php
+/**
+ * Class to define a single comment.
+ *
+ * @author      Lee Garner <lee@leegarner.com>
+ * @copyright   Copyright (c) 2022 Lee Garner
+ * @package     glfusion
+ * @version     v2.1.0
+ * @since       v2.1.0
+ * @license     http://opensource.org/licenses/gpl-2.0.php
+ *              GNU Public License v2 or later
+ * @filesource
+ */
+namespace glFusion\Comments\Internal;
+use \glFusion\Database\Database;
+use \glFusion\Cache\Cache;
+use \glFusion\Formatter;
+use \glFusion\Log\Log;
+use \glFusion\FieldList;
+use \glFusion\Comments\CommentEngine;
+
+
+/**
+ * This class displays the comment control bar.
+ * Prints the control that allows the user to interact with glFusion Comments.
+ * @package glfusion
+ */
+class CommentBar
+{
+    /** Story/Item ID.
+     * @var string */
+    private $sid = '';
+
+    /** Item title.
+     * @var string */
+    private $title = '';
+
+    /** Item type or plugin name.
+     * @var string */
+    private $type = 'article';
+
+    /** Sort order.
+     * @var string */
+    private $order = 'ASC';
+
+    /** View mode.
+     * @var string */
+    private $mode = '';
+
+    /** Comment code (enabled, disabled, closed).
+     * @var string */
+    private $ccode = '';
+
+
+    /**
+     * Set the story/item ID.
+     *
+     * @param   string  $sid    Story/Item ID.
+     * @return  object  $this
+     */
+    public function withSid(string $sid)
+    {
+        $this->sid = $sid;
+        return $this;
+    }
+
+
+    /**
+     * Set the item title.
+     *
+     * @param   string  $title  Item title
+     * @return  object  $this
+     */
+    public function withTitle(string $title)
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+
+    /**
+     * Set the item type.
+     *
+     * @param   string  $title  Item type
+     * @return  object  $this
+     */
+    public function withType(string $type)
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+
+    /**
+     * Set the sort direction.
+     *
+     * @param   string  $order  ASC or DESC
+     * @return  object  $this
+     */
+    public function withOrder(string $order)
+    {
+        $this->order = strtoupper($order);
+        return $this;
+    }
+
+
+    /**
+     * Set the view mode.
+     *
+     * @param   string  $view mode
+     * @return  object  $this
+     */
+    public function withMode(string $mode)
+    {
+        $this->mode = $mode;
+        return $this;
+    }
+
+
+    /**
+     * Set the comment code (enabled, disabled, closed)
+     *
+     * @param   string  $ccode  Comment code
+     * @return  object  $this
+     */
+    public function withCommentCode(bool $ccode) : self
+    {
+        $this->ccode = $ccode;
+        return $this;
+    }
+
+
+    /**
+     * Create the comment bar for display.
+     *
+     * @return  string      HTML for the comment bar
+     */
+    public function render()
+    {
+        global $_CONF, $_TABLES, $_USER, $LANG01, $LANG03;
+
+        $db = Database::getInstance();
+
+        $parts = explode( '/', $_SERVER['PHP_SELF'] );
+        $page = array_pop( $parts );
+
+        $sql = "SELECT COUNT(*) FROM `{$_TABLES['comments']}`
+            WHERE sid = ?
+                AND type = ?
+                AND queued = 0";
+        $nrows = $db->conn->fetchColumn($sql,array($this->sid,$this->type),0,array(Database::STRING,Database::STRING));
+
+        $T = new \Template( $_CONF['path_layout'] . 'comment' );
+        $T->set_file( array( 'commentbar' => 'commentbar.thtml' ));
+
+        if ( SESS_isSet('glfusion.commentpostsave') ) {
+            $msg = COM_showMessageText(SESS_getVar('glfusion.commentpostsave'),'',1,'warning');
+            SESS_unSet('glfusion.commentpostsave');
+            $T->set_var('info_message',$msg);
+        }
+
+        $T->set_var(array(
+            'lang_comments' => $LANG01[3],
+            'lang_refresh' => $LANG01[39],
+            'lang_reply' => $LANG01[60],
+            'html_type'=> htmlentities($this->type),
+            'html_sid' => htmlentities($this->sid),
+        ) );
+
+        if ( $nrows > 0 ) {
+            $T->set_var( 'lang_disclaimer', $LANG01[26] );
+        } else {
+            $T->set_var( 'lang_disclaimer', '' );
+        }
+
+        if ( !COM_isAnonUser() ) {
+            $T->set_var(array(
+                'can_subscribe' => 'true',
+                'subscribed' => PLG_isSubscribed('comment', $this->type, $this->sid),
+            ) );
+        }
+
+        if ( $this->ccode == CommentEngine::CLOSED ) {
+            $T->set_var( 'reply_hidden_or_submit', 'hidden');
+            $T->set_var( 'comment_option_text', $LANG03[49]);
+        } elseif ( $this->ccode == CommentEngine::DISABLED ) {
+            $T->set_var( 'reply_hidden_or_submit', 'hidden');
+            $T->set_var( 'comment_option_text', $LANG03[49]);
+        } elseif (
+            $this->ccode == CommentEngine::ENABLED &&
+            !CommentEngine::loginRequired()
+        ) {
+            $T->set_var( 'reply_hidden_or_submit', 'submit' );
+            $T->unset_var( 'comment_option_text');
+        } else {
+            $T->set_var( 'reply_hidden_or_submit', 'hidden' );
+            $T->set_var( 'comment_option_text', sprintf($LANG03[50],$_CONF['site_url']) );
+        }
+        $T->set_var( 'num_comments', COM_numberFormat( $nrows ));
+        $T->set_var( 'comment_type', $this->type );
+        $T->set_var( 'sid', $this->sid );
+
+        $cmt_title = $this->title;
+        $T->set_var('story_title', $cmt_title);
+        // Article's are pre-escaped.
+        if ($this->type != 'article') {
+            $cmt_title = @htmlspecialchars($cmt_title,ENT_COMPAT,COM_getEncodingt());
+        }
+        $T->set_var('comment_title', $cmt_title);
+
+        if( $this->type == 'article' ) {
+            $articleUrl = COM_buildUrl( $_CONF['site_url']."/article.php?story=$this->sid" );
+            $T->set_var( 'story_link', $articleUrl );
+            $T->set_var( 'article_url', $articleUrl );
+
+            if( $page == 'comment.php' ) {
+                $T->set_var('story_link',
+                    COM_createLink(
+                        $this->title,
+                        $articleUrl,
+                        array('class'=>'non-ul b')
+                    )
+                );
+                $T->set_var( 'start_storylink_anchortag', '<a href="'
+                    . $articleUrl . '" class="non-ul">' );
+                $T->set_var( 'end_storylink_anchortag', '</a>' );
+            }
+        } else { // for a plugin
+            // Link to plugin defined link or lacking that a generic link that the plugin should support (hopefully)
+            list($plgurl, $plgid) = PLG_getCommentUrlId($this->type);
+            $T->set_var( 'story_link', "$plgurl?$plgid=$this->sid" );
+            $cmt_title = @htmlspecialchars($cmt_title,ENT_COMPAT,COM_getEncodingt());
+        }
+        $T->set_var('comment_title', $cmt_title);
+        if (! COM_isAnonUser()) {
+            $username = $_USER['username'];
+            $fullname = $_USER['fullname'];
+        } else {
+            $N = $db->conn->fetchAssoc("SELECT username,fullname FROM `{$_TABLES['users']}` WHERE uid=1");
+            $username = $N['username'];
+            $fullname = $N['fullname'];
+        }
+        if( empty( $fullname )) {
+            $fullname = $username;
+        }
+        $T->set_var( 'user_name', $username );
+        $T->set_var( 'user_fullname', $fullname );
+
+        if (! COM_isAnonUser()) {
+            $author = COM_getDisplayName( $_USER['uid'], $username, $fullname );
+            $T->set_var( 'user_nullname', $author );
+            $T->set_var( 'author', $author );
+            $T->set_var( 'login_logout_url',
+                              $_CONF['site_url'] . '/users.php?mode=logout' );
+            $T->set_var( 'lang_login_logout', $LANG01[35] );
+        } else {
+            $T->set_var( 'user_nullname', '' );
+            $T->set_var( 'login_logout_url',
+                                  $_CONF['site_url'] . '/users.php?mode=new' );
+            $T->set_var( 'lang_login_logout', $LANG01[61] );
+        }
+
+        if( $page == 'comment.php' ) {
+            $T->set_var( 'parent_url',
+                              $_CONF['site_url'] . '/comment.php' );
+            $hidden = '';
+            $hmode = isset($_REQUEST['mode']) ? COM_applyFilter($_REQUEST['mode']) : 'entry';
+            if( $hmode == 'view' ) {
+                $hidden .= '<input type="hidden" name="cid" value="' . @htmlspecialchars(COM_applyFilter($_REQUEST['cid']),ENT_COMPAT,COM_getEncodingt()) . '"/>';
+                $hidden .= '<input type="hidden" name="pid" value="' . @htmlspecialchars(COM_applyFilter($_REQUEST['cid']),ENT_COMPAT,COM_getEncodingt()) . '"/>';
+            }
+            else if( $hmode == 'display' ) {
+                $hidden .= '<input type="hidden" name="pid" value="' . @htmlspecialchars(COM_applyFilter($_REQUEST['pid']),ENT_COMPAT,COM_getEncodingt()) . '"/>';
+            }
+            $T->set_var( 'hidden_field', $hidden .
+                '<input type="hidden" name="mode" value="' . @htmlspecialchars($hmode,ENT_COMPAT,COM_getEncodingt()) . '"/>' );
+        } else if( $this->type == 'article' ) {
+            $T->set_var( 'parent_url',
+                              $_CONF['site_url'] . '/article.php#comments' );
+            $T->set_var( 'hidden_field',
+                '<input type="hidden" name="story" value="' . $this->sid . '"/>' );
+        } else { // plugin
+            // Link to plugin defined link or lacking that a generic link that the plugin should support (hopefully)
+            list($plgurl, $plgid) = PLG_getCommentUrlId($this->type);
+            $T->set_var( 'parent_url', $plgurl );
+            $T->set_var( 'hidden_field',
+                '<input type="hidden" name="' . $plgid . '" value="' . $this->sid . '"/>' );
+        }
+
+        // Order
+        $selector_data = COM_optionList( $_TABLES['sortcodes'], 'code,name', $this->order );
+        $T->set_var( 'order_selector', $selector_data);
+
+        // Mode
+        $selector_data = COM_optionList( $_TABLES['commentmodes'], 'mode,name', $this->mode );
+        $T->set_var( 'mode_selector', $selector_data);
+        $T->set_var( 'mode_select_field_name', ($page == 'comment.php' ? 'format' : 'mode' ) ) ;
+
+        return $T->finish( $T->parse( 'output', 'commentbar' ));
+    }
+}
+
+

--- a/private/classes/Comments/Internal/CommentCollection.php
+++ b/private/classes/Comments/Internal/CommentCollection.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Class to handle comment collections.
+ *
+ * @author      Lee Garner <lee@leegarner.com>
+ * @copyright   Copyright (c) 2022 Lee Garner
+ * @package     glfusion
+ * @version     v2.1.0
+ * @since       v2.1.0
+ * @license     http://opensource.org/licenses/gpl-2.0.php
+ *              GNU Public License v2 or later
+ * @filesource
+ */
+namespace glFusion\Comments\Internal;
+use \glFusion\Database\Database;
+
+
+/**
+ * Class to abstact comment searching.
+ * @package glfusion
+ */
+class CommentCollection extends \glFusion\Collection
+{
+    /** Tags to add for caching.
+     * Userdata included to clear when comments are edited.
+     * @var array */
+    protected $cache_tags = array('comments', 'userdata');
+
+    /** Flag to indicate "pindent" has been set.
+     * If not set, "0 as pindent" will be added during execute() to ensure
+     * a field value is present.
+     * @var boolean */
+    private $_pindent_set = false;
+
+    private $Comments = array();
+
+    /**
+     * Set up the common query elements for comments.
+     */
+    public function __construct()
+    {
+        global $_TABLES;
+
+        parent::__construct();
+        $this->_qb->select(
+            'c.*', 'u.username', 'u.fullname', 'u.photo', 'u.email',
+            'UNIX_TIMESTAMP(c.date) AS nice_date'
+        )
+                 ->from($_TABLES['comments'], 'c')
+                 ->leftJoin('c', $_TABLES['users'], 'u', 'u.uid = c.uid');
+    }
+
+
+    /**
+     * For nested layouts, get the comments sorted by left/right.
+     *
+     * @param   string  $mode   Mode (nested, flat)
+     * @return  object  $this;
+     */
+    public function withMode(string $mode) : self
+    {
+        global $_TABLES;
+
+        $this->_qb->addSelect($this->_db->conn->quote($mode) . ' AS mode');
+        if ($mode == 'nested') {
+            $this->_qb->addSelect('c2.indent AS pindent');
+            $this->_qb->join('c', $_TABLES['comments'], 'c2')
+                      ->andWhere('(c.lft >= c2.lft AND c.lft <= c2.rht)');
+            // Flag that pindent is set so it won't get added again during execute()
+            $this->_pindent_set = true;
+        } 
+        return $this;
+    }
+
+
+    /**
+     * Limit to queued or nonqueued comments.
+     *
+     * @param   boolean $queued     True for queued, false for not.
+     * @return  object  $this
+     */
+    public function withQueued(bool $queued=true) : self
+    {
+        $queued = $queued ? 1 : 0;
+        $this->_qb->andWhere('queued = :queued')
+                  ->setParameter('queued', $queued, Database::INTEGER);
+        return $this;
+    }
+
+
+    /**
+     * Set a field to group results.
+     *
+     * @param   string  $var    DB Field name
+     * @return  object  $this
+     */
+    public function withGroupBy(string $var) : self
+    {
+        $this->_qb->addGroupBy($var);
+        return $this;
+    }
+
+
+    /**
+     * Set the item ID to limit results.
+     *
+     * @param   string  $sid    Item ID
+     * @return  object  $this
+     */
+    public function withSid(string $sid) : self
+    {
+        $this->_qb->andWhere('c.sid = :sid')
+                  ->setParameter('sid', $sid);
+        return $this;
+    }
+
+
+    /**
+     * Set the item type, e.g. "article" or plugin name.
+     *
+     * @param   string  $type   Item type
+     * @return  object  $this
+     */
+    public function withType(string $type) : self
+    {
+        $this->_qb->andWhere('c.type = :type')
+                  ->setParameter('type', $type, Database::STRING);
+        return $this;
+    }
+
+
+    /**
+     * Set the field or value for indentation.
+     *
+     * @param   string  $val    Field name or value
+     * @return  object  $this
+     */
+    public function withPindent(bool $val=true) : self
+    {
+        $this->_qb->addSelect($this->_db->conn->quote($val) . ' AS pindent');
+        return $this;
+    }
+
+
+    /**
+     * Push a single comment into the collection.
+     *
+     * @param   object  $Comment    Comment object
+     * @return  object  $this
+     */
+    public function pushComment(Comment $C) : self
+    {
+        $this->Comments[] = $C;
+        return $this;
+    }
+
+
+    /**
+     * Get an array of Comment objects.
+     *
+     * @return  array   Array of Result objects
+     */
+    public function getObjects() : array
+    {
+        $this->Comments = $this->tryCache();
+        if (is_array($this->Comments)) {
+            return $this->Comments;
+        }
+
+        $this->Comments = array();
+        if ($this->_stmt) {
+            while ($row = $this->_stmt->fetchAssociative()) {
+                $this->Comments[] = Comment::fromArray($row);
+            }
+            // only cache a good DB response
+            $this->setCache($this->Comments, $this->cache_tags);
+        }
+        return $this->Comments;
+    }
+
+
+    /**
+     * Returns the raw Comments array.
+     *
+     * @return  array   Array of comment records.
+     */
+    public function getComments() : array
+    {
+        return $this->Comments;
+    }
+
+
+    /**
+     * Wrapper to execute the query.
+     * Adds a selection value for 'pindent' if not already added.
+     *
+     * @return  object      Query result statement
+     */
+    public function execute() : object
+    {
+        if (!$this->_pindent_set) {
+            $this->_qb->addSelect('0 AS pindent');
+        }
+        return parent::execute();
+    }
+
+}
+

--- a/private/classes/Comments/Internal/CommentCollection.php
+++ b/private/classes/Comments/Internal/CommentCollection.php
@@ -52,6 +52,20 @@ class CommentCollection extends \glFusion\Collection
 
 
     /**
+     * Filter results by author user ID.
+     *
+     * @param   integer $uid    User ID
+     * @return  object  $this
+     */
+    public function withUid(int $uid) : self
+    {
+        $this->_qb->andWhere('c.uid = :uid')
+                  ->setParameter('uid', $uid, Database::INTEGER);
+        return $this;
+    }
+
+
+    /**
      * For nested layouts, get the comments sorted by left/right.
      *
      * @param   string  $mode   Mode (nested, flat)
@@ -68,7 +82,7 @@ class CommentCollection extends \glFusion\Collection
                       ->andWhere('(c.lft >= c2.lft AND c.lft <= c2.rht)');
             // Flag that pindent is set so it won't get added again during execute()
             $this->_pindent_set = true;
-        } 
+        }
         return $this;
     }
 
@@ -82,7 +96,7 @@ class CommentCollection extends \glFusion\Collection
     public function withQueued(bool $queued=true) : self
     {
         $queued = $queued ? 1 : 0;
-        $this->_qb->andWhere('queued = :queued')
+        $this->_qb->andWhere('c.queued = :queued')
                   ->setParameter('queued', $queued, Database::INTEGER);
         return $this;
     }

--- a/private/classes/Comments/Internal/CommentForm.php
+++ b/private/classes/Comments/Internal/CommentForm.php
@@ -1,0 +1,507 @@
+<?php
+/**
+ * Class to create a comment entry form.
+ *
+ * @author      Lee Garner <lee@leegarner.com>
+ * @copyright   Copyright (c) 2022 Lee Garner
+ * @package     glfusion
+ * @version     v2.1.0
+ * @since       v2.1.0
+ * @license     http://opensource.org/licenses/gpl-2.0.php
+ *              GNU Public License v2 or later
+ * @filesource
+ */
+namespace glFusion\Comments\Internal;
+use \glFusion\Database\Database;
+use \glFusion\Cache\Cache;
+use \glFusion\Formatter;
+use \glFusion\Log\Log;
+use \glFusion\FieldList;
+use \glFusion\Comments\CommentEngine;
+
+
+/**
+ * Create a comment entry form.
+ * @package glfusion
+ */
+class CommentForm
+{
+    /** Editing mode (adminedit, previewedit, etc.)
+     * @var string */
+    private $mode = '';
+
+    /** Record ID of the comment being edited. 0 indicates a new submission.
+     * @var integer */
+    private $cid = 0;
+
+    /** item id.
+     * @var string */
+    private $sid = '';
+
+    /** Item title.
+     * @var string */
+    private $title = '';
+
+    /** Item type, e.g. plugin name.
+     * @var string */
+    private $type = 'article';
+
+    /** Post mode.
+     * @var string */
+    private $postmode = '';
+
+    /** Parent comment ID, when replying.
+     * @var string */
+    private $pid = 0;
+
+    /** Comment object being edited.
+     * @var object */
+    private $Comment = NULL;
+
+
+    /**
+     * Set the comment record ID and load a Comment object.
+     *
+     * @param   integer $cid    Comment ID
+     * @return  object  $this
+     */
+    public function withCid(int $cid) : self
+    {
+        $this->cid = $cid;
+        $this->Comment = Comment::getByCid($cid);
+        return $this;
+    }
+
+
+    /**
+     * Load the Comment from an existing object and set the CID from it.
+     *
+     * @param   object  $Comment    Comment object
+     * @return  object  $this
+     */
+    public function withComment(Comment $Comment) : self
+    {
+        $this->Comment = $Comment;
+        $this->cid = $this->Comment->getCid();
+        return $this;
+    }
+
+
+    /**
+     * Set the editing mode.
+     *
+     * @param   string  $mode   Edit mode
+     * @return  object  $this
+     */
+    public function withMode(string $mode) : self
+    {
+        $this->mode = $mode;
+        return $this;
+    }
+
+
+    /**
+     * Set the story/item ID.
+     *
+     * @param   string  $sid    Item ID
+     * @return  object  $this
+     */
+    public function withSid(string $sid) : self
+    {
+        $this->sid = $sid;
+        return $this;
+    }
+
+
+    /**
+     * Set the item type or plugin name.
+     *
+     * @param   string  $type   Item type
+     * @return  object  $this
+     */
+    public function withType(string $type) : self
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+
+    /**
+     * Set the comment's parent ID.
+     *
+     * @param   integer $pid    Parent record ID
+     * @return  object  $this
+     */
+    public function withPid(int $pid) : self
+    {
+        $this->pid = $pid;
+        return $this;
+    }
+
+
+    /**
+     * Set the item title string.
+     *
+     * @param   string  $title  Item title
+     * @return  object  $this
+     */
+    public function withTitle(string $title) : self
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+
+    /**
+     * Displays the comment form.
+     *
+     * @return  string      HTML for editing form
+     */
+    public function render() : string
+    {
+        global $_CONF, $_TABLES, $_USER, $LANG03, $LANG12, $LANG_LOGIN, $LANG_ACCESS, $LANG_ADMIN;
+
+        $retval         = '';
+        $cid            = 0;
+        $edit_comment   = '';
+        $moderatorEdit  = false;
+        $adminEdit      = false;
+
+        // bail if anonymous user and we require login
+        if (CommentEngine::loginRequired()) {
+            $retval .= SEC_loginRequiredForm();
+            return $retval;
+        }
+
+        if ($this->Comment === NULL) {
+            // Instantiate a comment if the Cid or Comment was not specified
+            $this->Comment = new Comment;
+            $this->cid = 0;
+        }
+
+        $postmode = $this->Comment->getPostmode();
+
+        $db = Database::getInstance();
+
+        switch ($this->mode) {
+        case 'modedit' :
+            if (Comment::isModerator()) {
+                $moderatorEdit = true;
+                $_CONF['skip_preview'] = 1;
+            }
+            $this->mode = 'edit';
+            break;
+        case 'preview_edit_mod' :
+            if (Comment::isModerator()) {
+                $moderatorEdit = true;
+                $_CONF['skip_preview'] = 1;
+            }
+            $this->mode = 'preview_edit';
+            break;
+        case 'adminedit' :
+            if (Comment::isModerator()) {
+                $adminEdit = true;
+                $_CONF['skip_preview'] = 1;
+            }
+            $this->mode = 'edit';
+            break;
+        case 'preview_edit_admin' :
+            if (Comment::isModerator()) {
+                $adminEdit = true;
+                $_CONF['skip_preview'] = 1;
+            }
+            $this->mode = 'preview_edit';
+            break;
+        default :
+            break;
+        }
+
+        if (empty($this->postmode)) {
+            $this->postmode = $_CONF['comment_postmode'];
+        }
+
+        $filter = \sanitizer::getInstance();
+        $AllowedElements = $filter->makeAllowedElements($_CONF['htmlfilter_comment']);
+        $filter->setAllowedelements($AllowedElements);
+        $filter->setNamespace('glfusion','comment');
+        $filter->setCensorData(true);
+        $filter->setPostmode($postmode);
+
+        if (COM_isAnonUser()) {
+            $uid = 1;
+        } else {
+            $uid = $_USER['uid'];
+        }
+        $commentuid = $uid;
+
+        if ( ($this->mode == 'edit' || $this->mode == 'preview_edit') && $this->cid > 0) {
+            $commentuid = $this->Comment->getUid();
+        }
+
+        COM_clearSpeedlimit ($_CONF['commentspeedlimit'], 'comment');
+
+        $last = 0;
+        if (
+            $this->mode != 'edit' &&
+            $this->mode != 'preview' &&
+            $this->mode != 'preview_new' &&
+            $this->mode != 'preview_edit'
+        ) {
+            //not edit mode or preview changes
+            $last = COM_checkSpeedlimit ('comment');
+        }
+        if ($last > 0) {
+            $retval .= COM_showMessageText($LANG03[7].$last.sprintf($LANG03[8],$_CONF['commentspeedlimit']),$LANG12[26],false,'error');
+            return $retval;
+        }
+
+        // Preview mode:
+        if (
+            (
+                $this->mode == 'preview' ||
+                $this->mode == 'preview_new' ||
+                $this->mode == 'preview_edit'
+            ) && !empty($this->Comment->getComment())
+        ) {
+            $start = new \Template( $_CONF['path_layout'] . 'comment' );
+            $start->set_file( array( 'comment' => 'startcomment.thtml' ));
+            $start->set_var( 'hide_if_preview', 'style="display:none"' );
+
+            // Clean up all the vars
+            $A = array();
+            foreach ($_POST as $key => $value) {
+                if (($key == 'pid') || ($key == 'cid')) {
+                    $A[$key] = (int) COM_applyFilter ($_POST[$key], true);
+                } else if (($key == 'title') || ($key == 'comment') || ($key == 'comment_text')) {
+                    $A[$key] = $_POST[$key];
+                } else if ($key == 'username') {
+//@@ we probably don't need to do this here
+//   since we really want the raw data
+//   we can do the filtering on display or edit below
+                    $A[$key] = @htmlspecialchars(COM_checkWords(strip_tags($_POST[$key])),ENT_QUOTES,COM_getEncodingt());
+                    $A[$key] = USER_uniqueUsername($A[$key]);
+                } else {
+                    $A[$key] = COM_applyFilter($_POST[$key]);
+                }
+            }
+
+            //correct time and username for edit preview
+            if ($this->mode == 'preview' || $this->mode == 'preview_new' || $this->mode == 'preview_edit') {
+                $A['nice_date'] = $this->Comment->getDate();
+
+                // not an anonymous user
+                /*if ( $commentuid > 1 ) {
+                    // get username from DB - we don't allow
+                    // logged-in-users to set or change their name
+                    $A['username'] = $db->conn->fetchColumn(
+                        "SELECT username FROM `{$_TABLES['users']}` WHERE uid=?",
+                        array($commentuid),
+                        0,
+                        array(Database::INTEGER)
+                    );
+                } else {
+                    // we have an anonymous user - so $_POST['username'] should be set
+                    // already from above
+                }*/
+
+            }
+            if (empty ($A['username'])) {
+                $A['username'] = $db->conn->fetchColumn(
+                    "SELECT username FROM `{$_TABLES['users']}` WHERE uid=?",
+                    array($commentuid),
+                    0,
+                    array(Database::INTEGER)
+                );
+            }
+
+            $author_id = PLG_getItemInfo($this->Comment->getType(), $this->Comment->getSid(), 'author');
+            $A['comment'] = $A['comment_text'];
+
+            // Create the preview of this comment. Use the CommentCollection
+            // but manually supply the comment.
+            $Comment = Comment::fromArray($A);
+            $Coll = new CommentCollection;
+            $Coll->pushComment($Comment);
+            $thecomments = CommentEngine::getEngine()->renderComments($Coll);
+            $start->set_var( 'comments', $thecomments );
+            $retval .= '<a name="comment_entry"></a>';
+            $retval .= COM_startBlock ($LANG03[14])
+                . $start->finish( $start->parse( 'output', 'comment' ))
+                . COM_endBlock ();
+        } else if ($this->mode == 'preview_new' || $this->mode == 'preview_edit') {
+            $retval .= COM_showMessageText($LANG03[12],$LANG03[17],true,'error');
+            $this->mode = 'error';
+        }
+
+        $T = new \Template($_CONF['path_layout'] . 'comment');
+        $T->set_file('form','commentform.thtml');
+
+        if ($this->mode == 'preview_new' ) {
+            $T->set_var('mode','new');
+            $T->set_var('show_anchor','');
+        } else if ($this->mode == 'preview_edit' ) {
+            $T->set_var('mode','edit');
+            $T->set_var('show_anchor','');
+        } else {
+            $T->set_var('mode',$this->mode);
+            $T->set_var('show_anchor',1);
+        }
+        $T->set_var('start_block_postacomment', COM_startBlock($LANG03[1]));
+        if ($_CONF['show_fullname'] == 1) {
+            $T->set_var('lang_username', $LANG_ACCESS['name']);
+        } else {
+            $T->set_var('lang_username', $LANG03[5]);
+        }
+        $T->set_var('sid', $this->Comment->getSid());
+        $T->set_var('pid', $this->Comment->getPid());
+        $T->set_var('type', $this->Comment->getType());
+
+        if ($this->mode == 'edit' || $this->mode == 'preview_edit') { //edit modes
+        	$T->set_var('start_block_postacomment', COM_startBlock($LANG03[41]));
+            $T->set_var('cid', '<input type="hidden" name="cid" value="' .
+                @htmlspecialchars(COM_applyFilter($this->cid),ENT_COMPAT,COM_getEncodingt()) . '"/>'
+            );
+        } else {
+            $T->set_var('start_block_postacomment', COM_startBlock($LANG03[1]));
+    	    $T->set_var('cid', '');
+        }
+  	    $T->set_var('CSRF_TOKEN', SEC_createToken());
+      	$T->set_var('token_name', CSRF_TOKEN);
+
+        if (! COM_isAnonUser()) {
+            if ( $moderatorEdit == true || $adminEdit == true ) {
+                // we know we are editing
+                $T->set_var('uid', $commentuid);
+
+                if  (isset($A['username'])) {
+                    $username = $A['username'];
+                } else {
+                    $username = $db->conn->fetchColumn(
+                        "SELECT name FROM `{$_TABLES['comments']}` WHERE cid=?",
+                        array($cid),
+                        0,
+                        array(Database::INTEGER)
+                    );
+                }
+                if ( empty($username)) {
+                    $username = $LANG03[24]; //anonymous user
+                }
+                $T->set_var('username',$filter->editableText($username));
+                if ( $commentuid > 1 ) {
+                    $T->set_var('username_disabled','disabled="disabled"');
+                } else {
+                    $T->unset_var('username_disabled');
+                }
+            } else {
+                $T->set_var('uid', $_USER['uid']);
+                $name = COM_getDisplayName($_USER['uid'], $_USER['username'],$_USER['fullname']);
+                $T->set_var('username', $filter->editableText($name));
+                $T->set_var('action_url',$_CONF['site_url'] . '/users.php?mode=logout');
+                $T->set_var('lang_logoutorcreateaccount',$LANG03[03]);
+                $T->set_var('username_disabled','disabled="disabled"');
+            }
+
+            if ( !$moderatorEdit && !$adminEdit) {
+                $T->set_var('suballowed',true);
+                $isSub = 0;
+                if ( $this->mode == 'preview_edit' || $this->mode == 'preview_new' ) {
+                    $isSub = isset($_POST['subscribe']) ? 1 : 0;
+                } else if (PLG_isSubscribed('comment',$this->Comment->getType(), $this->Comment->getSid())) {
+                    $isSub = 1;
+                }
+                if ( $isSub == 0 ) {
+                    $subchecked = '';
+                } else {
+                    $subchecked = 'checked="checked"';
+                }
+                $T->set_var('subchecked',$subchecked);
+            }
+        } else {
+            //Anonymous user
+            $T->set_var('uid', 1);
+
+            if ( isset($A['username'])) {
+                $name = USER_uniqueUsername($A['username']);
+            } else {
+                $name = $LANG03[24]; //anonymous user
+            }
+            $T->set_var('username', $filter->editableText($name));
+
+            $T->set_var('action_url', $_CONF['site_url'] . '/users.php?mode=new');
+            $T->set_var('lang_logoutorcreateaccount',$LANG03[04]);
+            $T->unset_var('username_disabled');
+        }
+
+        if ( $postmode == 'html' ) {
+            $T->set_var('htmlmode',true);
+        }
+        $T->set_var(array(
+            'lang_title' => $LANG03[16],
+            'title' => $filter->editableText($this->Comment->getTitle()),
+            'lang_timeout' => $LANG_ADMIN['timeout_msg'],
+            'lang_comment' => $LANG03[9],
+            'comment' => $filter->editableText($this->Comment->getComment()),
+            'lang_postmode' => $LANG03[2],
+            'postmode' => $postmode,
+            'postmode_options' => COM_optionList($_TABLES['postmodes'],'code,name',$postmode),
+            'lang_importantstuff' => $LANG03[18],
+            'lang_instr_line1' => $LANG03[19],
+            'lang_instr_line2' => $LANG03[20],
+            'lang_instr_line3' => $LANG03[21],
+            'lang_instr_line4' => $LANG03[22],
+            'lang_instr_line5' => $LANG03[23],
+        ) );
+        if ( $postmode == 'html' ) {
+            $T->set_var('allowed_html', $filter->getAllowedHTML() . '<br/>'. COM_AllowedAutotags('', false, 'glfusion','comment'));
+        } else {
+            $T->set_var('allowed_html', COM_AllowedAutotags('', false, 'glfusion','comment'));
+        }
+
+        if ($this->mode == 'edit' || $this->mode == 'preview_edit') {
+            //editing comment or preview changes
+            $T->set_var('lang_preview', $LANG03[28]);
+        } else {
+    	    //new comment
+            $T->set_var('lang_preview', $LANG03[14]);
+        }
+
+        if (function_exists('msg_replaceEmoticons'))  {
+            $T->set_var('smilies',msg_showsmilies());
+        }
+
+        $T->unset_var('save_type');
+        // allow plugins the option to set some template vars
+        PLG_templateSetVars ('comment', $T);
+
+        // set up the save / preview buttons
+        if ($this->mode == 'preview_edit' || ($this->mode == 'edit' && $_CONF['skip_preview'] == 1) ) {
+            //for editing
+            $T->set_var('save_type','saveedit');
+            $T->set_var('lang_save',$LANG03[29]);
+        } elseif (($_CONF['skip_preview'] == 1) || ($this->mode == 'preview_new')) {
+            //new comment
+            $T->set_var('save_type','savecomment');
+            $T->set_var('lang_save',$LANG03[11]);
+        }
+
+        // set some fields if mod or admin edit
+        if ( $moderatorEdit == true ) {
+            $T->set_var('modedit_mode','modedit');
+            $T->set_var('modedit','x');
+        }
+        if ( $adminEdit == true ) {
+            $T->set_var('modedit_mode','adminedit');
+            $T->set_var('modedit','x');
+            $T->set_var('silent_edit',true);
+            $T->set_var('lang_silent_edit', $LANG03[57]);
+        }
+
+        $T->set_var('end_block', COM_endBlock());
+        $T->parse('output', 'form');
+        $retval .= $T->finish($T->get_var('output'));
+
+        return $retval;
+    }
+
+}
+

--- a/private/classes/Comments/Internal/Engine.php
+++ b/private/classes/Comments/Internal/Engine.php
@@ -1,0 +1,695 @@
+<?php
+/**
+ * Implement the Internal comment engine.
+ *
+ * @author      Lee Garner <lee@leegarner.com>
+ * @copyright   Copyright (c) 2022 Lee Garner
+ * @package     glfusion
+ * @version     v2.1.0
+ * @since       v2.1.0
+ * @license     http://opensource.org/licenses/gpl-2.0.php
+ *              GNU Public License v2 or later
+ * @filesource
+ */
+namespace glFusion\Comments\Internal;
+use \glFusion\Database\Database;
+use \glFusion\Formatter;
+use \glFusion\User;
+
+
+/**
+ * Internal comment engine functions.
+ * @package glfusion
+ */
+class Engine extends \glFusion\Comments\CommentEngine
+{
+
+    /**
+     * Controls the entire comment section display.
+     * Collects the comments for an item and displays them.
+     *
+     * @see     self::renderComments()
+     * @return  string      HTML for the comments area
+     */
+    public function displayComments()
+    {
+        global $_CONF, $_TABLES, $_USER, $LANG03;
+
+        $retval = '';
+
+        $db = Database::getInstance();
+
+        if (!COM_isAnonUser()) {
+            try {
+                $U = $db->conn->executeQuery(
+                    "SELECT commentorder,commentmode,commentlimit
+                    FROM `{$_TABLES['usercomment']}` WHERE uid = ?",
+                    array($_USER['uid']),
+                    array(Database::INTEGER)
+                )->fetchAssociative();
+            } catch (\Throwable $e) {
+                Log::write('system', Log::ERROR, __METHOD__ . ': ' . $e->getMessage());
+                $U = false;
+            }
+            if (is_array($U)) {
+                // Set options if not already set.
+                if (empty( $this->order)) {
+                    $this->withOrder($U['commentorder']);
+                }
+                if (empty($this->mode)) {
+                    $this->withMode($U['commentmode']);
+                }
+                $limit = (int)$U['commentlimit'];
+            }
+        } else {
+            $limit = (int) $_CONF['comment_limit'];
+        }
+
+        if ($this->delete_option === NULL) {
+            // Set the delete option based on the current user's moderator
+            // status if not set otherwise.
+            $this->delete_option = PLG_callFunctionForOnePlugin(
+                'plugin_ismoderator_' . $this->type
+            );
+        }
+
+        if( !is_numeric($this->page) || $this->page < 1 ) {
+            $this->page = 1;
+        } else {
+            $this->page = (int) $this->page;
+        }
+
+        $start = (int) $limit * ( $this->page - 1 );
+
+        $T = new \Template( $_CONF['path_layout'] . 'comment' );
+        $T->set_file( array( 'commentarea' => 'startcomment.thtml' ));
+        if ( $this->mode != 'nobar' ) {
+            $CommentBar = new CommentBar;
+            $T->set_var(
+                'commentbar',
+                $CommentBar->withSid($this->sid)
+                           ->withTitle($this->title)
+                           ->withType($this->type)
+                           ->withOrder($this->order)
+                           ->withMode($this->mode)
+                           ->withCommentCode($this->ccode)
+                           ->render()
+            );
+        }
+        $T->set_var( 'sid', $this->sid );
+        $T->set_var( 'comment_type', $this->type );
+
+        if ($this->mode == 'nested' || $this->mode == 'flat') {
+            // build query
+            $Coll = new CommentCollection;
+            $Coll->withType($this->type)
+                 ->withSid($this->sid)
+                 ->withLimit($start, $limit)
+                 ->withMode($this->mode);
+            switch( $this->mode ) {
+            case 'flat':
+                if ($this->cid) {
+                    $count = 1;
+                } else {
+                    $count = $db->conn->executeQuery(
+                        "SELECT COUNT(*) FROM `{$_TABLES['comments']}` WHERE sid=? AND type=? AND queued=0",
+                        array($this->sid, $this->type),
+                        array(Database::STRING, Database::STRING)
+                    )->fetchOne();
+                    $Coll->withOrderBy('c.date', $this->order);
+                }
+                break;
+
+            case 'nested':
+            default:
+                if( $this->order == 'DESC' ) {
+                    $Coll->withOrderBy('c.rht', 'DESC');
+                } else {
+                    $Coll->withOrderBy('c.lft', 'ASC');
+                }
+                $Coll->withGroupBy('c.cid');
+
+                // We can simplify the query, and hence increase performance
+                // when pid = 0 (when fetching all the comments for a given sid)
+                if ( $this->cid ) {  // pid refers to commentid rather than parentid
+                    // count the total number of applicable comments
+                    $count = $db->conn->executeQuery(
+                        "SELECT COUNT(*)
+                        FROM `{$_TABLES['comments']}` AS c, `{$_TABLES['comments']}` AS c2
+                        WHERE c.queued = 0 AND c.sid = ? AND (c.lft >= c2.lft AND c.lft <= c2.rht)
+                        AND c2.cid = ? AND c.type = ?",
+                        array($this->sid, $this->pid, $this->type),
+                        array(Database::STRING, Database::INTEGER, Database::STRING)
+                    )->fetchOne();
+                    $count = (int)$count;
+                } else {
+                    // pid refers to parentid rather than commentid
+                    if( $this->pid == 0 ) {
+                        // the simple, fast case, count the total number of applicable comments
+                        $count = $db->conn->executeQuery(
+                            "SELECT COUNT(*) FROM `{$_TABLES['comments']}`
+                            WHERE sid=? AND type=? AND queued=0",
+                            array($this->sid, $this->type),
+                            array(Database::STRING, Database::STRING)
+                        )->fetchOne();
+                    } else {
+                        // count the total number of applicable comments
+                        $count = $db->conn->executeQuery(
+                            "SELECT COUNT(*)
+                            FROM `{$_TABLES['comments']}` AS c, `{$_TABLES['comments']}` AS c2
+                            WHERE c.queued = 0
+                                AND c.sid = ?
+                                AND (c.lft > c2.lft AND c.lft < c2.rht)
+                                AND c2.cid = ?
+                                AND c.type=?",
+                            array($this->sid, $this->pid, $this->type),
+                            array(Database::STRING, Database::INTEGER, Database::STRING)
+                        )->fetchOne();
+                    }
+                }
+                break;
+            }
+
+            // Actually get all the comments and insert into the template.
+            $Coll->execute()->getObjects();     // execute and load comments
+            $thecomments = $this->renderComments($Coll);
+            if (empty($thecomments)) {
+                if ( $this->ccode == self::ENABLED ) {
+                    $T->set_var( 'lang_be_the_first',$LANG03[51]);
+                }
+            } else {
+                $T->set_var( 'comments', $thecomments );
+            }
+
+            // Pagination
+            $tot_pages =  ceil( $count / $limit );
+
+            if( $this->type == 'article' ) {
+                $pLink = $_CONF['site_url'] . "/article.php?story={$this->sid}&amp;type={$this->type}&amp;order={$this->order}&amp;mode={$this->mode}";
+                $pageStr = 'page=';
+            } else {        // plugin
+                // Link to plugin defined link or lacking that a generic link
+                // that the plugin should support (hopefully)
+                $parts = PLG_getCommentUrlId($this->type);
+                var_dump($parts);die;
+                if (is_array($parts)) {
+                    $pLink = "{$parts[0]}?{$parts[1]}={$this->sid}" .
+                        "&amp;type={$this->type}&amp;order={$this->order}&amp;mode={$this->mode}";
+                    if (isset($parts[2]) && !empty($parts[2])) {
+                        $pageStr = $parts[2];
+                    } else {
+                        $pageStr = 'page=';
+                    }
+                }
+            }
+            $T->set_var(
+                'pagenav',
+                COM_printPageNavigation($pLink, $this->page, $tot_pages, $pageStr, false, '', '', '#comments')
+            );
+        }
+        $retval = $T->finish($T->parse('output', 'commentarea'));
+        return $retval;
+    }
+
+
+    /**
+     * This function prints &$comments (db results set of comments) in comment format
+     * -For previews, &$comments is assumed to be an associative array containing
+     *  data for a single comment.
+     */
+    public function renderComments(CommentCollection $Coll) : string
+    {
+        global $_CONF, $_TABLES, $_USER, $LANG01, $LANG03, $MESSAGE, $_IMAGE_TYPE;
+
+        $indent = 0;  // begin with 0 indent
+        $retval = ''; // initialize return value
+        static $userInfo = array();
+
+        $T = new \Template($_CONF['path_layout'] . 'comment');
+        $T->set_file(array(
+            'comment' => 'comment.thtml',
+            //'thread'  => 'thread.thtml'
+        ) );
+
+        // generic template variables
+        $T->set_var( 'lang_authoredby', $LANG01[42] );
+        $T->set_var( 'lang_on', $LANG01[36] );
+        $T->set_var( 'lang_permlink', $LANG01[120] );
+        $T->set_var( 'order', $this->order );
+
+        if( $this->ccode == self::ENABLED && (!self::loginRequired())) {
+            $T->set_var( 'lang_replytothis', $LANG01[43] );
+            $T->set_var( 'lang_reply', $LANG01[25] );
+        } else {
+            $T->set_var( 'lang_replytothis', '' );
+            $T->set_var( 'lang_reply', '' );
+        }
+
+        // Make sure we have a default value for comment indentation
+        if( !isset( $_CONF['comment_indent'] )) {
+            $_CONF['comment_indent'] = 25;
+        }
+
+        // Build the comment data record
+
+/*
+        //@TODO - appears if $preview is true- we pass the results instead of the result set
+        if ($this->preview) {
+            if ( isset($comments['comment_text'])) {
+                $comments['comment'] = $comments['comment_text'];
+            }
+
+            $A = $comments;
+            if( empty( $A['nice_date'] )) {
+                $A['nice_date'] = time();
+            }
+            if( !isset( $A['cid'] )) {
+                $A['cid'] = 0;
+            }
+            if( !isset( $A['photo'] )) {
+                if( isset( $_USER['photo'] )) {
+                    $A['photo'] = $_USER['photo'];
+                } else {
+                    $A['photo'] = '';
+                }
+            }
+            if (! isset($A['email'])) {
+                if (isset($_USER['email'])) {
+                    $A['email'] = $_USER['email'];
+                } else {
+                    $A['email'] = '';
+                }
+            }
+            $A['name'] = $A['username'];
+            $this->mode = 'flat';
+            $T->set_var('preview_mode',true);
+            $resultSet[] = $A;
+        } else {
+            //@TODO - $comments is passed from another function -
+            //          really isn't a good practice -
+            $resultSet = $comments->fetchAll(Database::ASSOCIATIVE);
+            $T->unset_var('preview_mode');
+        }
+ */
+        $resultSet = $Coll->getComments();
+        if (count($resultSet) == 0 ) {
+            return '';
+        }
+
+        // initialize our format class
+
+        $filter = \sanitizer::getInstance();
+        $filter->setNamespace('glfusion','comment');
+        $filter->setPostmode('text');
+
+        $format = new Formatter();
+        $format->setNamespace('glfusion');
+        $format->setAction('comment');
+        $format->setAllowedHTML($_CONF['htmlfilter_comment']);
+        $format->setParseAutoTags(true);
+        $format->setProcessBBCode(false);
+        $format->setCensor(true);
+        $format->setProcessSmilies(true);
+
+        $token = '';
+        if ($this->delete_option && !$this->preview) {
+            $token = SEC_createToken();
+        }
+
+        $row = 1;
+
+        // Using an array instead of a Comment object since we'll be
+        // pushing values into it that don't exist for the comment, such as
+        // signature and photo.
+        foreach ($resultSet as $A) {
+            if (!isset($A['postmode']) || empty($A['postmode'])) {
+                //get format mode
+                if ( preg_match( '/<.*>/', $A['comment'] ) != 0 ) {
+                    $postmode = 'html';
+                } else {
+                    $postmode = 'plaintext';
+                }
+            } else {
+                $postmode = $A['postmode'];
+            }
+
+            //remove any old signatures signature
+            $pos = strpos( $A['comment'],'<!-- COMMENTSIG --><div class="comment-sig">');
+            if ( $pos > 0) {
+                $A['comment'] = substr($A['comment'], 0, $pos);
+            } else {
+                $pos = strpos( $A['comment'],'<p>---<br />');
+                if ( $pos > 0 ) {
+                    $A['comment'] = substr($A['comment'], 0, $pos);
+                }
+            }
+
+            // get user information for this comment author
+            if ( !isset($A['uid']) || empty($A['uid'])) {
+                $A['uid'] = 1;
+            }
+
+            if ( $A['uid'] > 1 ) {
+                $User = User::getInstance($A['uid']);
+                $A['username'] = $User->username;
+                $A['remoteusername'] = $User->remoteusername;
+                $A['remoteservice'] = $User->remoteservice;
+                $A['fullname'] = $User->fullname;
+                $A['sig'] = $User->sig;
+                $A['photo'] = $User->photo;
+            }
+            $format->setType($postmode);
+
+            $commentFooter = '';
+
+            // fixes previous encodings...
+            if ( $postmode == 'plaintext') {
+                $A['comment'] = htmlspecialchars_decode($A['comment']);
+                $postmode = 'text';
+            }
+
+            $T->unset_var('delete_link');
+            $T->unset_var('ipaddress');
+            $T->unset_var('reply_link');
+            $T->unset_var('edit_link');
+
+            $db = Database::getInstance();
+            //check for comment edit
+            $B = $db->conn->executeQuery(
+                "SELECT cid,uid,UNIX_TIMESTAMP(time) as time
+                FROM `{$_TABLES['commentedits']}` WHERE cid = ?",
+                array($A['cid']),
+                array(Database::INTEGER)
+            )->fetchAssociative();
+            if ($B) { //comment edit present
+                //get correct editor name
+                if ($A['uid'] == $B['uid']) {
+                    $editname = $A['username'];
+                } else {
+                    $editname = $db->conn->executeQuery(
+                        "SELECT username FROM `{$_TABLES['users']}` WHERE uid = ?",
+                        array($B['uid']),
+                        array(Database::INTEGER)
+                    )->fetchOne();
+                }
+                //add edit info to text
+                $dtObject = new \Date($B['time'],$_USER['tzid']);
+
+                $commentFooter .= LB . '<div class="comment-edit">' . $LANG03[30] . ' '
+                                          . $dtObject->format($_CONF['date'],true) . ' ' . $LANG03[31] . ' '
+                                          . $editname . '</div><!-- /COMMENTEDIT -->';
+            }
+
+            // determines indentation for current comment
+            if($this->mode == 'nested') {
+                $indent = ($A['indent'] - $A['pindent']) * $_CONF['comment_indent'];
+            }
+
+            // comment variables
+            $T->set_var(array(
+                'indent'        => $indent,
+                'author_name'   => $filter->sanitizeUsername($A['username']),
+                'author_id'     => $A['uid'],
+                'cid'           => $A['cid'],
+                'pid'           => $A['pid'],
+                'cssid'         => $row % 2,
+                'author_match'  => $this->sid_author_id > 1 && $this->sid_author_id == $A['uid'],
+            ) );
+
+            if ($A['uid'] > 1) {
+                $fullname = COM_getDisplayName(
+                    $A['uid'], $A['username'], isset($A['fullname']) ? $A['fullname'] : ''
+                );
+                $T->set_var( 'author_fullname', $fullname );
+                $T->set_var( 'author', $fullname );
+                $alttext = $fullname;
+
+                $photo = '';
+                if ($_CONF['allow_user_photo']) {
+                    if (isset ($A['photo']) && empty ($A['photo'])) {
+                        $A['photo'] = '';
+                    }
+
+                    $photo = $User->getPhoto();
+                    $photo_raw = $User->getPhoto(64, 0);
+                    if (!empty($photo)) {
+                        $T->set_var('author_photo', $photo);
+                        $T->set_var('author_photo_raw',$photo_raw);
+                        $camera_icon = '<img src="' . $_CONF['layout_url']
+                            . '/images/smallcamera.' . $_IMAGE_TYPE . '" alt=""/>';
+                        $T->set_var(
+                            'camera_icon',
+                            COM_createLink(
+                                $camera_icon,
+                                $_CONF['site_url'] . '/users.php?mode=profile&amp;uid=' . $A['uid']
+                            )
+                        );
+                    } else {
+                        $T->set_var( 'author_photo', '<img src="'.$_CONF['default_photo'].'" alt="" class="userphoto"/>' );
+                        $T->set_var( 'author_photo_raw', $_CONF['default_photo']);
+                        $T->set_var( 'camera_icon', '' );
+                    }
+                } else {
+                    $T->set_var( 'author_photo_raw', '' );
+                    $T->set_var( 'author_photo', '' );
+                    $T->set_var( 'camera_icon', '' );
+                }
+
+                $T->set_var( 'start_author_anchortag', '<a href="'
+                    . $_CONF['site_url'] . '/users.php?mode=profile&amp;uid='
+                    . $A['uid'] . '">' );
+                $T->set_var( 'end_author_anchortag', '</a>' );
+                $T->set_var( 'author_link',
+                    COM_createLink(
+                        $fullname,
+                        $_CONF['site_url'] . '/users.php?mode=profile&amp;uid=' . $A['uid']
+                    )
+                );
+                $T->set_var( 'author_url', $_CONF['site_url'] . '/users.php?mode=profile&amp;uid=' . $A['uid']);
+            } else {
+                // anonymous user
+                $username = $filter->sanitizeUsername($A['name']);
+                if ( $username == '' ) {
+                    $username = $LANG01[24];
+                }
+
+                $T->set_var( 'author', $username);
+                $T->set_var( 'author_fullname', $username);
+                $T->set_var( 'author_link', @htmlspecialchars($username,ENT_COMPAT,COM_getEncodingt() ));
+                $T->unset_var( 'author_url');
+
+                if( $_CONF['allow_user_photo'] ) {
+                    $T->set_var( 'author_photo_raw', $_CONF['default_photo'] );
+                    $T->set_var( 'author_photo', '<img src="'.$_CONF['default_photo'].'" alt="" class="userphoto"/>' );
+                    $T->set_var( 'camera_icon', '' );
+                } else {
+                    $T->set_var( 'author_photo_raw', '' );
+                    $T->set_var( 'author_photo', '' );
+                    $T->set_var( 'camera_icon', '' );
+                }
+                $T->set_var( 'start_author_anchortag', '' );
+                $T->set_var( 'end_author_anchortag', '' );
+            }
+
+            // hide reply link from anonymous users if they can't post replies
+            $hidefromanon = false;
+            if (self::loginRequired()) {
+                $hidefromanon = true;
+            }
+
+            // this will hide HTML that should not be viewed in preview mode
+            if( $this->preview || $hidefromanon ) {
+                $T->set_var( 'hide_if_preview', 'style="display:none"' );
+            } else {
+                $T->set_var( 'hide_if_preview', '' );
+            }
+
+            $dtObject = new \Date($A['nice_date'],$_USER['tzid']);
+
+            $T->set_var( 'date', $dtObject->format($_CONF['date'],true));
+            $T->set_var( 'iso8601_date', $dtObject->toISO8601() );
+            $T->set_var( 'sid', $A['sid'] );
+            $T->set_var( 'type', $A['type'] );
+
+            //COMMENT edit rights
+            $edit_type = 'edit'; // normal user edit
+            if (!COM_isAnonUser()) {
+                if ( $_USER['uid'] == $A['uid'] && $_CONF['comment_edit'] == 1
+                    && ($_CONF['comment_edittime'] == 0 || ((time() - $A['nice_date']) < $_CONF['comment_edittime'] )) &&
+                    $this->ccode == self::ENABLED &&
+                    ($db->conn->fetchColumn("SELECT COUNT(*) FROM `{$_TABLES['comments']}`
+                        WHERE queued=0 AND pid=?",array($A['cid']),0,array(Database::INTEGER)) == 0)) {
+                    $edit_option = true;
+                } else if (SEC_hasRights('comment.moderate') ) {
+                    $edit_option = true;
+                    $edit_type   = 'adminedit';
+                } else {
+                    $edit_option = false;
+                }
+            } else {
+                $edit_option = false;
+            }
+
+            //edit link
+            if ($edit_option && !$this->preview) {
+                $editlink = $_CONF['site_url'] . '/comment.php?mode='.$edit_type.'&amp;cid='
+                    . $A['cid'] . '&amp;sid=' . $A['sid'] . '&amp;type=' . $this->type
+                    . '#comment_entry';
+                $T->set_var('edit_link',$editlink);
+                $T->set_var('lang_edit',$LANG01[4]);
+                $edit = COM_createLink( $LANG01[4], $editlink) . ' | ';
+            } else {
+                $editlink = '';
+                $edit = '';
+            }
+
+            // If deletion is allowed, displays delete link
+            if( $this->delete_option && !$this->preview) {
+                $deloption = '';
+                if ( SEC_hasRights('comment.moderate') ) {
+                    if( !empty( $A['ipaddress'] ) ) {
+                        if( empty( $_CONF['ip_lookup'] )) {
+                            $deloption = $A['ipaddress'] . '  | ';
+                            $T->set_var('ipaddress', $A['ipaddress']);
+                        } else {
+                            $iplookup = str_replace( '*', $A['ipaddress'], $_CONF['ip_lookup'] );
+                            $T->set_var('iplookup_link', $iplookup);
+                            $T->set_var('ipaddress', $A['ipaddress']);
+                            $deloption = COM_createLink($A['ipaddress'], $iplookup) . ' | ';
+                        }
+                        //insert re-que link here
+                    }
+                }
+                $dellink = $_CONF['site_url'] . '/comment.php?mode=delete&amp;cid='
+                    . $A['cid'] . '&amp;sid=' . $A['sid'] . '&amp;type=' . $this->type
+                    . '&amp;' . CSRF_TOKEN . '=' . $token;
+                $delattr = array('onclick' => "return confirm('{$MESSAGE[76]}');");
+
+                $delete_link = $dellink;
+                $T->set_var('delete_link',$delete_link);
+                $T->set_var('lang_delete_link_confirm',$MESSAGE[76]);
+                $T->set_var('lang_delete',$LANG01[28]);
+                $deloption .= COM_createLink( $LANG01[28], $dellink, $delattr) . ' | ';
+                $T->set_var( 'delete_option', $deloption . $edit);
+            } else if ( $edit_option) {
+                $T->set_var( 'delete_option', $edit );
+            } elseif (! COM_isAnonUser()) {
+                $reportthis = '';
+                if ($A['uid'] != $_USER['uid']) {
+                    $reportthis_link = $_CONF['site_url']
+                        . '/comment.php?mode=report&amp;cid=' . $A['cid']
+                        . '&amp;type=' . $this->type;
+                    $report_attr = array('title' => $LANG01[110]);
+                    $T->set_var('report_link',$reportthis_link);
+                    $T->set_var('lang_report',$LANG01[109]);
+                    $reportthis = COM_createLink($LANG01[109], $reportthis_link,
+                                             $report_attr) . ' | ';
+                }
+                $T->set_var( 'delete_option', $reportthis );
+            } else {
+                $T->set_var( 'delete_option', '' );
+            }
+
+            //and finally: format the actual text of the comment, but check only the text, not sig or edit
+
+            $text = str_replace('<!-- COMMENTSIG --><div class="comment-sig">', '', $A['comment']);
+            $text = str_replace('</div><!-- /COMMENTSIG -->', '', $text);
+            $text = str_replace('<div class="comment-edit">', '', $text);
+            $A['comment'] = str_replace('</div><!-- /COMMENTEDIT -->', '', $text);
+
+            // create a reply to link
+            $reply_link = '';
+            if ($this->ccode == self::ENABLED && !self::loginRequired()) {
+                $reply_link = $_CONF['site_url'] . '/comment.php?sid=' . $A['sid']
+                        . '&amp;pid=' . $A['cid'] . '&amp;title='
+                        . urlencode($A['title']) . '&amp;type=' . $A['type']
+                        . '#comment_entry';
+                $T->set_var('reply_link',$reply_link);
+                $T->set_var('lang_reply',$LANG01[43]);
+                $reply_option = COM_createLink($LANG01[43], $reply_link,
+                                           array('rel' => 'nofollow')) . ' | ';
+                $T->set_var('reply_option', $reply_option);
+            } else {
+                $T->set_var( 'reply_option', '' );
+            }
+            $T->set_var( 'reply_link', $reply_link );
+
+            // format title for display, must happen after reply_link is created
+            $A['title'] = @htmlspecialchars( $A['title'],ENT_COMPAT,COM_getEncodingt() );
+
+            $T->set_var( 'title', $A['title'] );
+
+            // add signature if available
+            $sig = isset($A['sig']) ? $filter->censor($A['sig']) : '';
+            $finalsig = '';
+            if ($A['uid'] > 1 && !empty($sig)) {
+                $finalsig .= '<div class="comment-sig">';
+                $finalsig .= nl2br('---' . LB . $sig);
+                $finalsig .= '</div>';
+            }
+
+            // sanitize and format comment
+            $A['comment'] = $format->parse($A['comment']);
+
+            // highlight search terms if specified. After formatting to avoid introducing
+            // strange comment fields
+            if( !empty( $_REQUEST['query'] )) {
+                $A['comment'] = COM_highlightQuery( $A['comment'], strip_tags($_REQUEST['query']) );
+            }
+
+            $T->set_var( 'comments',  $A['comment'].$finalsig.$commentFooter);
+
+            // parse the templates. Note that 'threaded' is not a valid mode.
+            /*if(($this->mode == 'threaded') && $indent > 0) {
+                $T->set_var('pid', $A['pid']);
+                $retval .= $T->parse('output', 'thread');
+            } else {*/
+                $T->set_var('pid', $A['cid']);
+                $retval .= $T->parse('output', 'comment');
+            //}
+            if ($this->preview) {
+                // only comment to show
+                return $retval;
+            }
+            $row++;
+        }
+        unset($format);
+        return $retval;
+    }
+
+
+    /**
+     * Get a link to the comment display, with the number of comments.
+     *
+     * @param   string  $type       Item type
+     * @param   string  $sid        Item ID
+     * @param   string  $url        URL to comment display
+     * @param   integer $cmtCount   Optional number of comments
+     */ 
+    public function getLinkWithCount(string $type, string $sid, string $url, ?int $cmtCount = NULL) : array
+    {
+        global $_TABLES, $LANG01;
+
+        if ($cmtCount === NULL) {
+            $cmtCount = (int)Database::getInstance()->getCount(
+                $_TABLES['comments'],
+                array('type', 'sid'),
+                array($type, $sid),
+                array(Database::STRING, Database::STRING)
+            );
+        }
+
+        $link = '<a href="'.$url.'#comments">';
+        $retval = array(
+            'url'           => $url,
+            'url_extra'     => '',
+            'link'          => $link,
+            'nonlink'       => '',
+            'comment_count' => $cmtCount . ' '. $LANG01[83],
+            'comment_text'  => $LANG01[83],
+            'link_with_count' => $link . ' ' . $cmtCount . ' ' . $LANG01[83].'</a>',
+        );
+        return $retval;
+    }
+}
+

--- a/private/system/classes/outputhandler.class.php
+++ b/private/system/classes/outputhandler.class.php
@@ -345,6 +345,28 @@ class outputHandler {
         $this->_footer['script'][$priority][] = $link;
     }
 
+
+	/**
+	 * Add a JavaScript source footer section of page
+	 *
+	 * Adds a raw footer script entry. The code must be fully formed and include
+	 * all necessary HTML. No manipulations are done to the data.
+	 *
+	 * @param  string   $href       The URL to the javascript file
+	 * @param  int      $priority   Load priority
+	 * @param  string   $mime       The mime type of the stylesheet, 'text/css'
+	 *                              used if no other type passed.
+	 * @param  boolean  $async      true - load script asynchronously
+     *
+	 * @access public
+	 * @return nothing
+	 */
+    public function addRawScriptFooter(string $code, int $priority = HEADER_PRIO_NORMAL, string $mime = 'text/javascript', bool$async = false) : void
+    {
+        $this->_footer['script'][$priority][] = $code;
+    }
+
+
 	/**
 	 * Add JavaScript to footer section of page
 	 *

--- a/public_html/layout/cms/comment/commentbar.thtml
+++ b/public_html/layout/cms/comment/commentbar.thtml
@@ -11,9 +11,13 @@
 		<li><strong>{story_title}</strong></li>
 		<li>{num_comments} {lang_comments}</li>
 
-		{!if subscribe}
-		<li><a class="uk-form-small" href="{subscribe_url}">{subscribe_text}</a></li>
+{!if can_subscribe}
+		{!if subscribed}
+		<li>[<a href="{site_url}/comment.php?mode=unsubscribe&amp;type={html_type}&amp;sid={html_sid}" rel="nofollow">{$LANG01['unsubscribe']}</a>]</li>
+		{!else}
+        <li>[<a href="{site_url}/comment.php?mode=subscribe&amp;type={html_type}&amp;sid={html_sid}" rel="nofollow">{$LANG01['subscribe']}</a>]</li>
 		{!endif}
+{!endif}
 	</ul>
 </div>
 

--- a/public_html/lib-common.php
+++ b/public_html/lib-common.php
@@ -1412,8 +1412,10 @@ function COM_siteFooter( $rightblock = -1, $custom = '' )
     }
 
     $jsFooter = '<script src="'.$_CONF['layout_url'].'/js/footer.js"></script>';
+
     if (isset($_CONF['comment_engine']) ) {
-        switch ($_CONF['comment_engine']) {
+        $theme->set_var('integrated_comments', glFusion\Comments\CommentEngine::getEngine()->getApiCode());
+/*        switch ($_CONF['comment_engine']) {
             case 'disqus' :
                 $jsFooter .= '<script id="dsq-count-scr" src="//'.$_CONF['comment_disqus_shortname'].'.disqus.com/count.js" async></script>';
                 break;
@@ -1422,7 +1424,7 @@ function COM_siteFooter( $rightblock = -1, $custom = '' )
                 '<div id="fb-root"></div><script>(function(d, s, id) {var js, fjs = d.getElementsByTagName(s)[0];if (d.getElementById(id)) return;js = d.createElement(s); js.id = id;js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.6";fjs.parentNode.insertBefore(js, fjs);}(document, \'script\', \'facebook-jssdk\'));</script>');
                 $outputHandle->addRaw('<meta property="fb:app_id" content="{'.$_CONF['comment_fb_appid'].'}" />');
                 break;
-         }
+        }*/
     }
     if ( isset($_CONF['syntax_highlight']) && $_CONF['syntax_highlight'] == true && (!isset($_SYSTEM['disable_jquery']) || $_SYSTEM['disable_jquery'] == false)) {
         $jsFooter .= '<script>hljs.initHighlightingOnLoad();</script>';


### PR DESCRIPTION
Initial refactoring of comment engines into classes to be a bit more self-contained and reduce distributed comment DB lookups and config checks.  Also includes a couple of new functions for outputHandler to add footer JS similar to the raw JS allowed for headers (needed by Disqus)