### PR TITLE
Fix URL Param Value in File Management Hits Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Several bug fixes
   - Media Gallery - fixed invalid path to mediagallery.gif in user profile
   - Fixed language reference where it would throw an error if a language file was not found
+  - Fixed File Management Administration 'Hits' download history link
 
 ## v2.0.1 (March 6, 2022)
 

--- a/private/plugins/filemgmt/classes/Download.class.php
+++ b/private/plugins/filemgmt/classes/Download.class.php
@@ -1575,7 +1575,7 @@ class Download
             break;
 
         case 'hits' :
-            $retval = '<a href="'.$_CONF['site_url'].'/filemgmt/downloadhistory.php?lid='.$fieldvalue.'" target="_blank">';
+            $retval = '<a href="'.$_CONF['site_url'].'/filemgmt/downloadhistory.php?lid='.$A['lid'].'" target="_blank">';
             $retval .= COM_numberFormat($fieldvalue);
             $retval .= '</a>';
             break;


### PR DESCRIPTION
Recreated this Pull Request since I had trouble squashing the commits for the previous one. 

The 'lid' URL parameter value in the File Management Administration 'File Listing' page has the wrong value for the download history links in the 'Hits' column.

`private/plugins/filemgmt/classes/Download.class.php`
It was incorrectly using the number of hits as the lid parameter value. Updated the value in the link to the correct variable.