### PR TITLE
Fix handling expirations for popup messages, register Popup as a notifier

### DIFF
--- a/private/classes/Notifier.php
+++ b/private/classes/Notifier.php
@@ -255,7 +255,7 @@ abstract class Notifier
      * @param   boolean $default    False to return NULL instead of default
      * @return  object  Provider object
      */
-    public static function getProvider(string $key, bool $default=true) : object
+    public static function getProvider(string $key, bool $default=true) : ?object
     {
         $retval = NULL;
         if (array_key_exists($key, self::$_providers)) {

--- a/private/classes/Notifiers/Popup.php
+++ b/private/classes/Notifiers/Popup.php
@@ -255,8 +255,6 @@ class Popup extends \glFusion\Notifier
         global $MESSAGE, $_USER;
         $retval = '';
 
-        self::expire();
-
         $msgs = self::getByUid($_USER['uid']);
         if (empty($msgs)) {
             return '';

--- a/public_html/lib-common.php
+++ b/public_html/lib-common.php
@@ -7141,5 +7141,6 @@ if ( isset($_POST['token_revalidate']) ) {
 }
 
 glFusion\Notifier::Register('email', 'glFusion\\Notifiers\\Email', $LANG04[5]);
+glFusion\Notifier::Register('popup', 'glFusion\\Notifiers\\Popup', $MESSAGE[40]);
 
 ?>


### PR DESCRIPTION
After merging I noticed that Popup::expire() wasn't used and caused an error. Messages are now expired via cron.php and Popup skips messages that may have expired since the last cron run. Also added registration for popups to lib-common.php.