### PR TITLE
Fix #583 - IP address wasn't provided to throttling function

### DIFF
--- a/private/classes/User/User.php
+++ b/private/classes/User/User.php
@@ -27,7 +27,7 @@ use glFusion\Notifiers\Email;
 abstract class User {
 
       /** @var string the user's current IP address */
-    private $ipAddress;
+    protected $ipAddress;
     /** @var bool whether throttling should be enabled (e.g. in production) or disabled (e.g. during development) */
     protected $throttling;
 


### PR DESCRIPTION
It looks like the intent was to use the client IP in creating the throttling key in UserAuth::__construct(), but because the parent class's $ipAddress property was private it was set as a different property and not retrieved by getIpAddress() in userLocalLoginController(). This made every request count against the token quota and could DOS valid users.