### PR TITLE
Allow cache disabling, make extra key string optional

### DIFF
--- a/private/classes/Comments/Internal/CommentCollection.php
+++ b/private/classes/Comments/Internal/CommentCollection.php
@@ -176,7 +176,7 @@ class CommentCollection extends \glFusion\Collection
      */
     public function getObjects() : array
     {
-        $this->Comments = $this->tryCache();
+        $this->Comments = $this->tryCache('obj');
         if (is_array($this->Comments)) {
             return $this->Comments;
         }


### PR DESCRIPTION
Two things discovered....
1. The CommentCollection::getObjects() wasn't updated to submit a key to Collection::tryCache(). The idea is that either the base getRows() function or a child class getObjects() function will be called, so as long as getRows() sets the key it can be optional for getObjects().
2. Since the cache key is based on the SQL query and parameters, some queries (RAND() comes to mind), caching the results that way doesn't work. Collection::withCache() can be called with "false" to disable caching if needed.